### PR TITLE
Remove immediate state saving from URL

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -328,7 +328,8 @@ export class CustomViewsCore {
     // 1. URL State
     const urlState = URLStateManager.parseURL();
     if (urlState) {
-      this.applyState(urlState);
+      // Apply URL state temporarily (do not persist until interaction)
+      this.applyState(urlState, { persist: false });
       return;
     }
 
@@ -345,11 +346,12 @@ export class CustomViewsCore {
 
   /**
   * Apply a custom state, saves to localStorage and updates the URL
-  * Add 'source' in options to indicate the origin of the state change
+  * 'source' in options indicates the origin of the state change
   * (e.g., 'widget' to trigger scroll behavior)
-  * Add scrollAnchor in options to maintain scroll position of a specific element
+  * 'scrollAnchor' in options indicates the element to maintain scroll position of
+  * 'persist' (default true) to control whether to save to localStorage
   */
-  public applyState(state: State, options?: { source?: string; scrollAnchor?: { element: HTMLElement; top: number; }; }) {
+  public applyState(state: State, options?: { source?: string; scrollAnchor?: { element: HTMLElement; top: number; }; persist?: boolean; }) {
     // console.log(`[Core] applyState called with source: ${options?.source}`, state);
 
     let groupToScrollTo: HTMLElement | null = null;
@@ -359,7 +361,12 @@ export class CustomViewsCore {
 
     const snapshot = this.cloneState(state);
     this.renderState(snapshot);
-    this.persistenceManager.persistState(snapshot);
+
+    // Only persist if explicitly requested (default true)
+    if (options?.persist !== false) {
+      this.persistenceManager.persistState(snapshot);
+    }
+
     if (this.showUrlEnabled) {
       URLStateManager.updateURL(snapshot);
     } else {

--- a/tests/core/core-persistence.test.ts
+++ b/tests/core/core-persistence.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { CustomViewsCore } from '../../src/core/core';
+import { AssetsManager } from '../../src/core/assets-manager';
+import { URLStateManager } from '../../src/core/url-state-manager';
+import type { Config } from '../../src/types/types';
+
+// Mock URLStateManager
+vi.mock('../../src/core/url-state-manager', async () => {
+    return {
+        URLStateManager: {
+            parseURL: vi.fn(),
+            updateURL: vi.fn(),
+            clearURL: vi.fn(),
+            generateShareableURL: vi.fn(),
+        }
+    };
+});
+
+describe('CustomViewsCore Persistence', () => {
+    let core: CustomViewsCore;
+    let mockAssetsManager: AssetsManager;
+    let mockConfig: Config;
+    let dom: JSDOM;
+
+    beforeEach(() => {
+        // Setup JSDOM
+        dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+            url: "http://localhost/"
+        });
+        global.window = dom.window as any;
+        global.document = dom.window.document as any;
+
+        // Mock localStorage
+        const storage: Record<string, string> = {};
+        global.localStorage = {
+            getItem: vi.fn((key) => storage[key] || null),
+            setItem: vi.fn((key, value) => { storage[key] = value }),
+            removeItem: vi.fn((key) => { delete storage[key] }),
+            clear: vi.fn(() => { for (const key in storage) delete storage[key] }),
+            key: vi.fn((index) => Object.keys(storage)[index] || null),
+            length: 0
+        } as any;
+
+        // Mock MutationObserver
+        global.MutationObserver = vi.fn().mockImplementation(() => ({
+            observe: vi.fn(),
+            disconnect: vi.fn(),
+            takeRecords: vi.fn(),
+        })) as any;
+
+        vi.clearAllMocks();
+
+        mockAssetsManager = {} as AssetsManager;
+        mockConfig = {
+            toggles: [{ id: 't1' }, { id: 't2' }],
+            defaultState: { toggles: ['t1'] }
+        };
+
+        const options = {
+            assetsManager: mockAssetsManager,
+            config: mockConfig,
+            rootEl: document.createElement('div'),
+            showUrl: false
+        };
+
+        core = new CustomViewsCore(options);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should NOT persist state to localStorage when persist option is false', () => {
+        const newState = { toggles: ['t2'] };
+        core.applyState(newState, { persist: false });
+
+        const storedState = localStorage.getItem('customviews-state');
+        expect(storedState).toBeNull();
+    });
+
+    it('should persist state to localStorage when persist option is true (default)', () => {
+        const newState = { toggles: ['t2'] };
+        core.applyState(newState);
+
+        const storedState = localStorage.getItem('customviews-state');
+        expect(storedState).not.toBeNull();
+        expect(JSON.parse(storedState!)).toEqual(newState);
+    });
+
+    it('should apply URL state temporarily and not persist it', async () => {
+        // Mock URL having a state
+        const urlState = { toggles: ['t2'] };
+        vi.spyOn(URLStateManager, 'parseURL').mockReturnValue(urlState);
+
+        // Re-initialize core to trigger loadAndCallApplyState
+        const options = {
+            assetsManager: mockAssetsManager,
+            config: mockConfig,
+            rootEl: document.createElement('div'),
+            showUrl: false
+        };
+        core = new CustomViewsCore(options);
+
+        // We need to wait for init or manually call init if we tested init()
+        // But the constructor calls common setup? No, init calls loadAndCallApplyState.
+        await core.init();
+
+        // Verify URLStateManager.parseURL was called
+        expect(URLStateManager.parseURL).toHaveBeenCalled();
+
+        // Verify state is applied (we can't easily check internal state, maybe check active toggles)
+        const activeToggles = core.getCurrentActiveToggles();
+        expect(activeToggles).toEqual(['t2']);
+
+        // Verify localStorage is EMPTY
+        const storedState = localStorage.getItem('customviews-state');
+        expect(storedState).toBeNull();
+    });
+});


### PR DESCRIPTION
**Overview of changes:**

Closes #46

Removes automatic and immediate persisting of URL state when users go to a customized URL shared by another user.

Instead, only upon further configuration of view will state be saved on localStorage.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
