### PR TITLE
Fix default toggles to visible before config loads and improve scroll

### DIFF
--- a/src/components/elements/Toggle.svelte
+++ b/src/components/elements/Toggle.svelte
@@ -38,6 +38,9 @@
 
   // Derive visibility from store state
   let showState = $derived.by(() => {
+      // Default to SHOWN if config hasn't loaded yet (prevent pop-in)
+      if (!store.config.toggles) return true;
+      
       const shownToggles = store.state.shownToggles ?? [];
       return toggleIds.some(id => shownToggles.includes(id));
   });

--- a/src/core/services/highlight-service.svelte.ts
+++ b/src/core/services/highlight-service.svelte.ts
@@ -2,6 +2,7 @@ import { mount, unmount } from 'svelte';
 import { showToast } from '../stores/toast-store.svelte';
 import { focusStore } from '../stores/focus-store.svelte';
 import * as DomElementLocator from '../utils/dom-element-locator';
+import { scrollToElement } from '../../utils/scroll-utils';
 import HighlightOverlay from '../../components/highlight/HighlightOverlay.svelte';
 
 export const HIGHLIGHT_PARAM = 'cv-highlight';
@@ -64,12 +65,15 @@ export class HighlightService {
 
         this.renderHighlightOverlay();        
         
-        // Scroll first target into view
+        // Scroll first target into view with header offset awareness
         const firstTarget = targets[0];
         if (firstTarget) {
-            setTimeout(() => {
-                firstTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }, 100);
+            // Use double-RAF to ensure layout stability (e.g. Svelte updates, animations)
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                   scrollToElement(firstTarget);
+                });
+            });
         }
     }
 


### PR DESCRIPTION
**Overview of changes:**

Closes #118 for now
Related to and kind of fixes issue faced in #119

1. The toggles were defaulted to take no space and would pop up upon loading config, but this caused the scrolling behavior to bug, as the scroll target would originally be in view, but bc component (toggles) popped up, pushed the element down.

Instead, default to show and hide on load, which fixes this issue.

Similar issue in #118 for hash scroll target

2. Update the scrolling 


Previously, the 

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
