### PR TITLE
Add drop shadow to highlight box

### DIFF
--- a/src/components/highlight/HighlightOverlay.svelte
+++ b/src/components/highlight/HighlightOverlay.svelte
@@ -75,7 +75,10 @@
   .cv-highlight-box {
     position: absolute;
     border: 4px solid #d13438;
-    box-shadow: 0 0 0 4px rgba(209, 52, 56, 0.2);
+    /* Layer 1: Sharp/Close, Layer 2: Soft/Deep */
+    box-shadow: 
+      0 5px 10px rgba(0, 0, 0, 0.1), 
+      0 15px 35px rgba(0, 0, 0, 0.15);
     pointer-events: none;
   }
 
@@ -88,6 +91,7 @@
     height: 30px;
     line-height: 30px;
     text-align: center;
+    filter: drop-shadow(5px 5px 5px rgba(0, 0, 0, 0.5));
   }
 
   .cv-highlight-arrow.left { animation: floatArrowLeft 1.5s infinite; }


### PR DESCRIPTION
**Overview of changes:**

Add drop shadow to highlight box to make it look less part of page

Prev:
<img width="1069" height="154" alt="image" src="https://github.com/user-attachments/assets/e99bfb5f-e9ef-4e3f-8ed6-6c7982cc7a08" />

New:
<img width="832" height="89" alt="image" src="https://github.com/user-attachments/assets/661d89b8-3bed-4057-b433-0c3c0425cf3c" />

For #120

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
