### PR TITLE
Fixes Placeholder component copy issue

### DIFF
--- a/src/components/elements/Placeholder.svelte
+++ b/src/components/elements/Placeholder.svelte
@@ -23,9 +23,21 @@
      // 4. Raw Name
      return `[[${name}]]`;
   });
+  function updateHost(node: HTMLElement) {
+    // With {@attach}, this function runs in an effect context
+    // and re-runs whenever dependencies (like `value`) change.
+    
+    // Write to the host's light DOM so that .textContent works on parent elements
+    // This is safe because we don't have <slot>s, so this text is never rendered
+    const host = node.getRootNode() as ShadowRoot;
+    if (host && host.host) {
+            const hostEl = host.host as HTMLElement;
+            hostEl.innerText = value;
+    }
+  }
 </script>
 
-<span class="cv-var">{value}</span>
+<span class="cv-var" {@attach updateHost}>{value}</span>
 
 <style>
   :host {


### PR DESCRIPTION
**Overview of changes:**

Fixes issue where placeholder does not get copied when in things like code blocks. We fix it by by mirroring resolved placeholder value to host element Light DOM which is not displayed, so that it can be read by the copy logic or even screen readers.

Identified the issue in #99

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
