### PR TITLE
Add tagConfig to MarkBind plugin

### DIFF
--- a/docs/_markbind/plugins/customviews.js
+++ b/docs/_markbind/plugins/customviews.js
@@ -19,5 +19,29 @@ function getScripts() {
   ];
 };
 
+const tagConfig = {
+  'cv-toggle': {
+    isCustomElement: true,
+  },
+  'cv-tabgroup': {
+    isCustomElement: true,
+  },
+  'cv-tab': {
+    isCustomElement: true,
+  },
+  'cv-tab-body': {
+    isCustomElement: true,
+  },
+  'cv-tab-header': {
+    isCustomElement: true,
+  },
+  'cv-define-placeholder': {
+    isCustomElement: true,
+  },
+  'cv-placeholder-input': {
+    isCustomElement: true,
+  }
+};
+
 // CJS: module.exports = { getScripts };
-export { getScripts };
+export { getScripts, tagConfig };


### PR DESCRIPTION
**Overview of changes:**

Adds tagConfig to the MarkBind Plugin script

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
