### PR TITLE
feat: Implement stable element text hashing for placeholders

### DIFF
--- a/src/lib/utils/dom-element-locator.ts
+++ b/src/lib/utils/dom-element-locator.ts
@@ -39,11 +39,17 @@ function normalizeText(text: string): string {
 }
 
 /**
- * Matches raw (un-hydrated) placeholder tokens in text content:
+ * Matches raw (un-hydrated) placeholder tokens in text content, including
+ * escaped forms like \[[ name ]]:
  *   [[ name ]], [[ name : fallback ]], [[ name ? truthy : falsy ]], \[[ name ]]
  * Captures the placeholder name in group 1. Used to normalize tokens before hashing.
+ *
+ * The optional `(?:\\)?` prefix intentionally consumes the leading backslash so that
+ * \[[ name ]] normalizes to [[name]] — the same canonical form that PlaceholderBinder
+ * emits for escaped tokens ([[ name ]] literal text). This keeps the hash stable
+ * across raw and hydrated DOM states.
  */
-const RAW_PLACEHOLDER_RE = /(?<!\\)\[\[\s*([a-zA-Z0-9_-]+)[^\]]*\]\]/g;
+const RAW_PLACEHOLDER_RE = /(?:\\)?\[\[\s*([a-zA-Z0-9_-]+)[^\]]*\]\]/g;
 
 /**
  * Recursively walks `node`, appending stable placeholder-canonical text to `parts`.
@@ -83,12 +89,16 @@ function getStableTextContent(el: HTMLElement): string {
   if (el.tagName === 'CV-PLACEHOLDER') {
     return `[[${el.getAttribute('name') || ''}]]`;
   }
-  // Fast path: if no <cv-placeholder> descendants and no raw [[ tokens,
+  // Fast path: if no raw [[ tokens and no <cv-placeholder> descendants,
   // there are no placeholders — return textContent directly (native, no allocation).
-  const hasHydrated = el.querySelector('cv-placeholder') !== null;
+  // Check textContent first to avoid the querySelector when raw tokens are present
+  // (raw DOM elements with [[ tokens always need the slow path).
   const rawText = el.textContent || '';
-  if (!hasHydrated && !rawText.includes('[[')) {
-    return rawText;
+  if (!rawText.includes('[[')) {
+    const hasHydrated = el.querySelector('cv-placeholder') !== null;
+    if (!hasHydrated) {
+      return rawText;
+    }
   }
   // Slow path: walk the DOM to canonicalize all placeholder forms.
   const parts: string[] = [];
@@ -372,13 +382,15 @@ export function resolve(root: HTMLElement, descriptor: AnchorDescriptor): HTMLEl
   // Optimization: Structural Check First (Fastest)
   // If we trust the structure hasn't changed, the element at the specific index
   // is effectively O(1) access if we assume `querySelectorAll` order is stable.
+  // Cache the computed text so the full scan can reuse it if this check fails.
+  let indexCandidateText: string | null = null;
   if (candidates[descriptor.index]) {
     const candidate = candidates[descriptor.index] as HTMLElement;
-    const text = getStableNormalizedText(candidate);
+    indexCandidateText = getStableNormalizedText(candidate);
 
     // Perfect Match Check: If index + hash match, it's virtually guaranteed.
     // This avoids checking every other candidate.
-    if (hashCode(text) === descriptor.textHash) {
+    if (hashCode(indexCandidateText) === descriptor.textHash) {
       return [candidate];
     }
   }
@@ -391,7 +403,10 @@ export function resolve(root: HTMLElement, descriptor: AnchorDescriptor): HTMLEl
   for (let i = 0; i < candidates.length; i++) {
     const candidate = candidates[i] as HTMLElement;
     let score = 0;
-    const text = getStableNormalizedText(candidate);
+    // Reuse already-computed text for the index candidate to avoid duplicate DOM walk.
+    const text = i === descriptor.index && indexCandidateText !== null
+      ? indexCandidateText
+      : getStableNormalizedText(candidate);
 
     // Content Match
     if (hashCode(text) === descriptor.textHash) {

--- a/tests/lib/utils/dom-element-locator.test.ts
+++ b/tests/lib/utils/dom-element-locator.test.ts
@@ -219,16 +219,19 @@ describe('DomElementLocator', () => {
         expect(descriptor.textSnippet).toBe('[[username]]');
       });
 
-      it('A7: escaped raw token hashes differently from real placeholder', () => {
-        container.innerHTML = `<p id="escaped">Hello \\[[ username ]]!</p>`;
-        const escapedEl = document.getElementById('escaped')!;
-        const escapedDescriptor = DomElementLocator.createDescriptor(escapedEl);
+      it('A7: escaped raw token has same hash as its post-PlaceholderBinder literal form', () => {
+        // Raw DOM: escaped token \[[ username ]] — before PlaceholderBinder runs
+        container.innerHTML = `<p id="raw">Hello \\[[ username ]]!</p>`;
+        const rawEl = document.getElementById('raw')!;
+        const rawDescriptor = DomElementLocator.createDescriptor(rawEl);
 
-        container.innerHTML = `<p id="real">Hello [[ username ]]!</p>`;
-        const realEl = document.getElementById('real')!;
-        const realDescriptor = DomElementLocator.createDescriptor(realEl);
+        // Hydrated DOM: PlaceholderBinder strips the backslash via fullMatch.slice(1),
+        // leaving the literal text [[ username ]] (with original spacing)
+        container.innerHTML = `<p id="hydrated">Hello [[ username ]]!</p>`;
+        const hydratedEl = document.getElementById('hydrated')!;
+        const hydratedDescriptor = DomElementLocator.createDescriptor(hydratedEl);
 
-        expect(escapedDescriptor.textHash).not.toBe(realDescriptor.textHash);
+        expect(rawDescriptor.textHash).toBe(hydratedDescriptor.textHash);
       });
     });
 


### PR DESCRIPTION
**Overview of changes:**

Fixes #200 when highlighted element contains a placeholder, which causes the content part of fingerprint to get thrown off, and not be found.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
