### PR TITLE
Fix adaptation bug: ?adapt=clear now wipes full user state including placeholders

### DIFF
--- a/src/lib/features/adaptation/adaptation-manager.ts
+++ b/src/lib/features/adaptation/adaptation-manager.ts
@@ -35,7 +35,8 @@ export class AdaptationManager {
 
     // 2. Handle ?adapt=clear
     if (queryParamValue === 'clear') {
-      this.clearStoredId(persistence);
+      persistence.clearAll();              // wipe custardUI-state and tab nav prefs
+      persistence.removeItem(STORAGE_KEY); // wipe the adaptation ID itself
       if (this.hasHashAdaptationId(url.hash)) {
         this.stripHashFromUrl(url);
       }
@@ -75,7 +76,12 @@ export class AdaptationManager {
       }
     }
 
-    // 7. Persist namespace
+    // 7. Persist namespace — clear old state if explicitly switching to a different adaptation
+    const previousId = persistence.getItem(STORAGE_KEY);
+    const isExplicitUrlSwitch = queryParamValue !== null; // ?adapt= was in the URL
+    if (isExplicitUrlSwitch && previousId !== null && previousId !== id) {
+      persistence.clearAll(); // Remove custardUI-state so new adaptation starts fresh
+    }
     persistence.setItem(STORAGE_KEY, id);
 
     // 8. Apply theme synchronously (FOUC prevention)
@@ -99,11 +105,15 @@ export class AdaptationManager {
   static rewriteUrlIndicator(adaptationId: string): void {
     const url = new URL(window.location.href);
     const targetHash = this.getHashUrlIndicator(adaptationId);
-    
-    if (url.hash === targetHash) return;
 
-    if (url.hash === '') {
+    const hashCorrect = url.hash === targetHash;
+    const noStaleParam = !url.searchParams.has(this.QUERY_PARAM);
+    if (hashCorrect && noStaleParam) return; // Already in correct state
+
+    if (url.hash === '' || url.hash === targetHash) {
+      // Hash is free — use #/id and remove any stale ?adapt= param
       url.hash = targetHash;
+      url.searchParams.delete(this.QUERY_PARAM);
     } else {
       // Hash is occupied (page anchor, #cv-open, etc.), use query param
       if (url.searchParams.get(this.QUERY_PARAM) === adaptationId) return;

--- a/src/lib/stores/active-state-store.svelte.ts
+++ b/src/lib/stores/active-state-store.svelte.ts
@@ -240,6 +240,15 @@ export class ActiveStateStore {
       }
     }
 
+    // 3. Seed author-controlled (adaptationPlaceholder) defaults.
+    // These are set by adaptations when active, and fall back to defaultValue when no adaptation is active.
+    // This is intentionally separate from regular user-settable placeholder defaults (see PR #206).
+    for (const def of placeholderRegistryStore.definitions) {
+      if (def.adaptationPlaceholder && def.defaultValue !== undefined && def.defaultValue !== '') {
+        placeholders[def.name] = def.defaultValue;
+      }
+    }
+
     return { shownToggles, peekToggles, tabs, placeholders };
   }
 

--- a/tests/lib/features/adaptation/adaptation-manager.test.ts
+++ b/tests/lib/features/adaptation/adaptation-manager.test.ts
@@ -47,6 +47,20 @@ describe('AdaptationManager', () => {
   });
 
   describe('init()', () => {
+    it('should wipe custardUI-state and cv-tab-navs-visible when ?adapt=clear is passed', async () => {
+      mockLocation('http://localhost/?adapt=clear');
+      localStorage.setItem('cv-adaptation', 'nus');
+      localStorage.setItem('custardUI-state', JSON.stringify({ placeholders: { institutionName: 'NUS Institution' } }));
+      localStorage.setItem('cv-tab-navs-visible', 'true');
+
+      const result = await AdaptationManager.init('');
+
+      expect(result).toBeNull();
+      expect(localStorage.removeItem).toHaveBeenCalledWith('custardUI-state');
+      expect(localStorage.removeItem).toHaveBeenCalledWith('cv-tab-navs-visible');
+      expect(localStorage.removeItem).toHaveBeenCalledWith('cv-adaptation');
+    });
+
     it('should clear stored id when ?adapt=clear is passed', async () => {
       mockLocation('http://localhost/?adapt=clear');
       localStorage.setItem('cv-adaptation', 'some-id');

--- a/tests/lib/stores/active-state-store.test.ts
+++ b/tests/lib/stores/active-state-store.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../../src/lib/features/placeholder/stores/placeholder-registry-store
     has: vi.fn().mockReturnValue(false),
     get: vi.fn().mockReturnValue(undefined),
     register: vi.fn(),
+    definitions: [],
   },
 }));
 


### PR DESCRIPTION
**Overview of changes:**

Previously, ?adapt=clear only removed the cv-adaptation key, leaving state (persisted placeholder values) intact in localStorage.

On the next load, stale adaptation values reloaded, visible even with no active adaptation.

The fix calls persistence.clearAll() before removeItem(STORAGE_KEY) so custardUI-state and cv-tab-navs-visible are also wiped on clear.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
