### PR TITLE
Update text annotation home plate shape to have fixed triangle shape

### DIFF
--- a/src/lib/features/highlight/HighlightTextAnnotation.svelte
+++ b/src/lib/features/highlight/HighlightTextAnnotation.svelte
@@ -144,9 +144,9 @@
   function getRibbonClipPath(c: AnnotationCorner): string {
     const pointsRight = c === 'tl' || c === 'bl';
     if (pointsRight) {
-      return 'polygon(0% 0%, 80% 0%, 100% 50%, 80% 100%, 0% 100%)';
+      return 'polygon(0% 0%, calc(100% - 14px) 0%, 100% 50%, calc(100% - 14px) 100%, 0% 100%)';
     } else {
-      return 'polygon(20% 0%, 100% 0%, 100% 100%, 20% 100%, 0% 50%)';
+      return 'polygon(14px 0%, 100% 0%, 100% 100%, 14px 100%, 0% 50%)';
     }
   }
 </script>


### PR DESCRIPTION

**Overview of changes:**

Adjust ribbon clip path polygons to use fixed pixel offsets instead of percentages.

Make text annotation shape look the same regardless of 

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
