### PR TITLE
Fix Labels

### DIFF
--- a/src/lib/features/labels/components/Label.svelte
+++ b/src/lib/features/labels/components/Label.svelte
@@ -19,12 +19,21 @@
 
   let hasSlotContent = $state(false);
 
-  function onSlotChange(e: Event): void {
-    const slot = e.target as HTMLSlotElement;
-    hasSlotContent = slot.assignedNodes({ flatten: true }).some(
-      (n) => n.nodeType === Node.ELEMENT_NODE || (n.textContent?.trim() ?? '') !== '',
-    );
-  }
+  $effect(() => {
+    const host = $host<HTMLElement>();
+
+    function update() {
+      hasSlotContent = Array.from(host.childNodes).some(
+        (n) => n.nodeType === Node.ELEMENT_NODE || (n.textContent?.trim() ?? '') !== '',
+      );
+    }
+
+    update();
+
+    const observer = new MutationObserver(update);
+    observer.observe(host, { childList: true, characterData: true, subtree: true });
+    return () => observer.disconnect();
+  });
 
   let labelDef = $derived(labelRegistryStore.get(name));
   let rawColor = $derived(labelDef?.color ?? (color || DEFAULT_COLOR));
@@ -37,11 +46,11 @@
     {#if labelDef?.value}
       {labelDef.value}
     {:else}
-      <slot onslotchange={onSlotChange}></slot>
+      <slot></slot>
     {/if}
   </span>
 {:else}
-  <slot onslotchange={onSlotChange}></slot>
+  <slot></slot>
 {/if}
 
 <style>


### PR DESCRIPTION

**Overview of changes:**

 What was broken

*  hasSlotContent was detected via onslotchange on the <slot> element.
 But <slot> was only rendered inside conditional branches that required
 hasSlotContent to already be true, labels not in
 config (where labelDef?.value is always falsy) never rendered.


 Replaced onslotchange with a MutationObserver on $host<HTMLElement>().
 - Calls update() immediately on mount to read initial light DOM children
 - Observer fires update() on any subsequent child mutations
 - No dependency on <slot> being in the DOM at detection time


<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
