### PR TITLE
Fix: disable settings widget by default and refactors

### DIFF
--- a/docs/authorGuide/configuration.md
+++ b/docs/authorGuide/configuration.md
@@ -79,7 +79,7 @@ Refer to individual components for more details on each configuration option.
 
 | Field                   | Type      | Default                                     | Description                                                                                                         |
 | ----------------------- | --------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| enabled                 | `boolean` | `true`                                      | Whether to show the floating settings widget on the page.                                                           |
+| enabled                 | `boolean` | `false`                                     | Whether to show the floating settings widget on the page.                                                           |
 | panel.title             | `string`  | `"Customize View"`                          | Title shown in settings tooltip and modal header.                                                                   |
 | panel.description       | `string`  | `""`                                        | Description text displayed in the settings modal.                                                                   |
 | panel.showTabGroups     | `boolean` | `true`                                      | Whether to show tab groups section in widget.                                                                       |

--- a/src/lib/app/ui-manager.ts
+++ b/src/lib/app/ui-manager.ts
@@ -83,7 +83,8 @@ export function initUIManager(
   runtime: AppRuntime,
   config: ConfigFile,
 ): CustardUIManager | undefined {
-  const settingsEnabled = config.settings?.enabled === true;
+  const { enabled, ...widgetSettings } = config.settings ?? {};
+  const settingsEnabled = enabled === true;
 
   const callbacks: RuntimeCallbacks = {
     resetToDefault: () => runtime.resetToDefault(),
@@ -94,7 +95,7 @@ export function initUIManager(
   const uiManager = new CustardUIManager({
     callbacks,
     settingsEnabled,
-    ...config.settings,
+    ...widgetSettings,
   });
   uiManager.render();
   return uiManager;

--- a/src/lib/utils/init-utils.ts
+++ b/src/lib/utils/init-utils.ts
@@ -1,76 +1,67 @@
 import { prependBaseUrl } from './url-utils';
 import type { ConfigFile } from '$lib/types/index';
 
-/**
- * structure for script attributes
- */
 export interface ScriptAttributes {
   baseURL: string;
   configPath: string;
 }
+
+const SCRIPT_ATTRIBUTE_DEFAULTS: ScriptAttributes = {
+  baseURL: '/',
+  configPath: '/custardui.config.json',
+};
+
+const FALLBACK_CONFIG: ConfigFile = {
+  config: {},
+  settings: { enabled: false },
+};
 
 /**
  * Finds the script tag that loaded the library and extracts configuration attributes.
  * Looks for `data-base-url` and `data-config-path`.
  */
 export function getScriptAttributes(): ScriptAttributes {
-  let scriptTag = document.currentScript as HTMLScriptElement | null;
-  const defaults = { baseURL: '/', configPath: '/custardui.config.json' };
+  const scriptTag = findScriptTag();
+  if (!scriptTag) return SCRIPT_ATTRIBUTE_DEFAULTS;
 
-  if (!scriptTag || !scriptTag.hasAttribute('data-base-url')) {
-    const dataAttrMatch = document.querySelector(
-      'script[data-base-url]',
-    ) as HTMLScriptElement | null;
-    if (dataAttrMatch) {
-      scriptTag = dataAttrMatch;
-    } else {
-      // Fallback: try to find script by src pattern
-      for (const script of document.scripts) {
-        const src = script.src || '';
-        if (
-          /(?:custard(?:ui)?|@custardui\/custard(?:ui)?)(?:\.min)?\.(?:esm\.)?js($|\?)/i.test(
-            src,
-          )
-        ) {
-          scriptTag = script as HTMLScriptElement;
-          break;
-        }
-      }
+  return {
+    baseURL: scriptTag.getAttribute('data-base-url') || SCRIPT_ATTRIBUTE_DEFAULTS.baseURL,
+    configPath: scriptTag.getAttribute('data-config-path') || SCRIPT_ATTRIBUTE_DEFAULTS.configPath,
+  };
+}
+
+function findScriptTag(): HTMLScriptElement | null {
+  const current = document.currentScript as HTMLScriptElement | null;
+  if (current?.hasAttribute('data-base-url')) return current;
+
+  const byAttr = document.querySelector('script[data-base-url]') as HTMLScriptElement | null;
+  if (byAttr) return byAttr;
+
+  // Fallback: find script by src pattern
+  for (const script of document.scripts) {
+    if (/(?:custard(?:ui)?|@custardui\/custard(?:ui)?)(?:\.min)?\.(?:esm\.)?js($|\?)/i.test(script.src)) {
+      return script as HTMLScriptElement;
     }
   }
 
-  if (scriptTag) {
-    return {
-      baseURL: scriptTag.getAttribute('data-base-url') || defaults.baseURL,
-      configPath: scriptTag.getAttribute('data-config-path') || defaults.configPath,
-    };
-  }
-
-  return defaults;
+  return null;
 }
 
 /**
  * Fetches and parses the configuration file.
+ * Returns the fallback config silently if the file is not found (404),
+ * since operating without a config file is a valid use case.
  */
 export async function fetchConfig(configPath: string, baseURL: string): Promise<ConfigFile> {
-  const fallbackMinimalConfig: ConfigFile = {
-    config: {},
-    settings: { enabled: true },
-  };
-
   try {
     const fullConfigPath = prependBaseUrl(configPath, baseURL);
     const response = await fetch(fullConfigPath);
 
-    if (!response.ok) {
-      console.warn(`[CustardUI] Config file not found at ${fullConfigPath}. Using defaults.`);
-      return fallbackMinimalConfig;
-    }
+    if (!response.ok) return FALLBACK_CONFIG;
 
-    const config = await response.json();
-    return config;
+    return await response.json();
   } catch (error) {
     console.error('[CustardUI] Error loading config file:', error);
-    return fallbackMinimalConfig;
+    return FALLBACK_CONFIG;
   }
 }


### PR DESCRIPTION
**Overview of changes:**

Previously, settings widget was still not disabled by default, updated it.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)
