### PR TITLE
Refactor light dark mode, use colorScheme to drive all themeing

### DIFF
--- a/docs/authorGuide/configuration.md
+++ b/docs/authorGuide/configuration.md
@@ -84,7 +84,6 @@ Refer to individual components for more details on each configuration option.
 | panel.description       | `string`  | `""`                                        | Description text displayed in the settings modal.                                                                   |
 | panel.showTabGroups     | `boolean` | `true`                                      | Whether to show tab groups section in widget.                                                                       |
 | panel.showReset         | `boolean` | `true`                                      | Whether to show the reset to default button.                                                                        |
-| panel.theme             | `string`  | `"light"`                                   | Widget theme: `"light"` or `"dark"`.                                                                                |
 | callout.show            | `boolean` | `false`                                     | Whether to show the callout.                                                                                        |
 | callout.message         | `string`  | `"Customize your reading experience here."` | Message to display in the callout.                                                                                  |
 | callout.enablePulse     | `boolean` | `true`                                      | Whether to enable pulse animation for the callout.                                                                  |
@@ -103,7 +102,7 @@ Refer to individual components for more details on each configuration option.
 | Field          | Type                           | Default   | Description                             |
 | -------------- | ------------------------------ | --------- | --------------------------------------- |
 | storageKey     | `string`                       | `null`    | Optional key to isolate localStorage settings across different sites. Used as a prefix (e.g., `my-unique-siteName`). |
-| colorScheme    | `"light" \| "dark" \| "auto"`  | `"light"` | Controls which color variant is used: `"light"`, `"dark"`, or `"auto"`. This is intended to match the site's light/dark mode, so a light mode website uses the light variant, and a dark mode website uses the dark variant. Auto switches based on the visitor's OS preference (`prefers-color-scheme`), reactively. If any other value is provided, CustardUI falls back to the `"light"` scheme (the default). |
+| colorScheme    | `"light" \| "dark" \| "auto"`  | `"light"` | Controls the color scheme for all CustardUI elements — the settings widget, modal, and on-page components such as `<cv-toggle-control>`. Set to `"light"` or `"dark"` to match your site's color scheme, or `"auto"` to follow the visitor's OS preference (`prefers-color-scheme`) reactively. If any other value is provided, CustardUI falls back to `"light"`. |
 
 **Example**: 
 ```json

--- a/docs/devGuide/changesMade.md
+++ b/docs/devGuide/changesMade.md
@@ -9,6 +9,21 @@
 
 Also refer to [release notes](https://github.com/CustardUI/custardui/releases) to view detailed changes and version history.
 
+### v.next
+
+**User Facing Changes**:
+
+* feat: Add `<cv-toggle-control/>` component
+* feat: Add baseline support for light and dark mode
+
+* chore: Deprecate `show-inline-control` attribute from `<cv-toggle/>`
+* chore: Deprecate and remove `panel.theme` setting, rely on single source of truth (`colorScheme`).
+
+**Developer Facing Changes**:
+
+
+
+
 ### v2.2.*
 
 **User Facing Changes**:

--- a/src/lib/app/UIRoot.svelte
+++ b/src/lib/app/UIRoot.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, getContext } from 'svelte';
+  import { onMount, onDestroy, getContext } from 'svelte';
   import { type ResolvedUIManagerOptions, type RuntimeCallbacks, RUNTIME_CALLBACKS_CTX } from './types';
   import { ICON_SETTINGS_CTX, type IconSettingsStore } from '$features/settings/stores/icon-settings-store.svelte';
   import { activeStateStore } from '$lib/stores/active-state-store.svelte';
@@ -65,11 +65,13 @@
     introManager.init(elementStore.hasElementsOnCurrentPage, settingsEnabled);
   });
 
-  // Always setAttribute (not removeAttribute) on transitions to avoid a brief FOUC gap.
-  // colorSchemeStore handles 'auto' via matchMedia and is initialised before UIRoot mounts.
+  // onDestroy (not $effect cleanup) so the attribute is never briefly absent during transitions.
   $effect(() => {
     document.documentElement.setAttribute('data-cv-theme', colorSchemeStore.isDark ? 'dark' : 'light');
-    return () => document.documentElement.removeAttribute('data-cv-theme');
+  });
+
+  onDestroy(() => {
+    document.documentElement.removeAttribute('data-cv-theme');
   });
 
   // --- Modal Actions ---

--- a/src/lib/app/UIRoot.svelte
+++ b/src/lib/app/UIRoot.svelte
@@ -20,6 +20,7 @@
 
   import { UrlActionRouter } from '$features/url/url-action-router.svelte';
   import { IntroManager } from '$features/settings/intro-manager.svelte';
+  import { colorSchemeStore } from '$lib/stores/color-scheme-store.svelte';
 
   let { options } = $props<{
     options: ResolvedUIManagerOptions;
@@ -64,11 +65,12 @@
     introManager.init(elementStore.hasElementsOnCurrentPage, settingsEnabled);
   });
 
-  // Mirror theme to <html> so CV variables 
-  // cascade to on-page custom elements (cv-toggle-control etc.)
+  // Mirror colorScheme to <html> so --cv-* variables cascade to
+  // on-page custom elements (cv-toggle-control etc.) via :root[data-cv-theme='dark'].
+  // colorSchemeStore is already initialised by AppRuntime before UIRoot mounts
+  // and handles 'auto' (matchMedia) internally.
   $effect(() => {
-    const theme = options.theme;
-    if (theme === 'dark') {
+    if (colorSchemeStore.isDark) {
       document.documentElement.setAttribute('data-cv-theme', 'dark');
     } else {
       document.documentElement.removeAttribute('data-cv-theme');
@@ -109,7 +111,7 @@
   );
 </script>
 
-<div class="cv-widget-root" data-theme={options.theme} data-cv-share-ignore>
+<div class="cv-widget-root" data-cv-share-ignore>
   <!-- Intro Callout -->
   {#if introManager.showCallout && settingsEnabled}
     <IntroCallout
@@ -244,40 +246,6 @@
   :global(.cv-widget-root .cv-share-overlay) {
     pointer-events: none; /* Overlay often passes clicks until specialized handles active */
   }
-
-  :global(.cv-widget-root[data-theme='dark']) {
-    /* Dark Theme Overrides */
-    --cv-bg: #101722;
-    --cv-text: #e2e8f0;
-    --cv-text-secondary: rgba(255, 255, 255, 0.6);
-    --cv-border: rgba(255, 255, 255, 0.1);
-    --cv-bg-hover: rgba(255, 255, 255, 0.05);
-
-    --cv-primary: #3e84f4;
-    --cv-primary-hover: #60a5fa;
-
-    --cv-danger: #f87171;
-    --cv-danger-bg: rgba(248, 113, 113, 0.1);
-
-    --cv-shadow: rgba(0, 0, 0, 0.5);
-
-    --cv-input-bg: #1e293b;
-    --cv-input-border: rgba(255, 255, 255, 0.1);
-    --cv-switch-bg: rgba(255, 255, 255, 0.1);
-    --cv-switch-knob: #e2e8f0;
-
-    --cv-modal-icon-bg: rgba(255, 255, 255, 0.08);
-    --cv-icon-bg: #1e293b;
-    --cv-icon-color: #e2e8f0;
-
-    --cv-focus-ring: rgba(62, 132, 244, 0.5);
-    --cv-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
-
-    --cv-modal-radius: 0.75rem;
-    --cv-card-radius: 0.5rem;
-    --cv-section-label-transform: uppercase;
-  }
-
 
   :global(.cv-hidden) {
     display: none !important;

--- a/src/lib/app/UIRoot.svelte
+++ b/src/lib/app/UIRoot.svelte
@@ -65,16 +65,10 @@
     introManager.init(elementStore.hasElementsOnCurrentPage, settingsEnabled);
   });
 
-  // Mirror colorScheme to <html> so --cv-* variables cascade to
-  // on-page custom elements (cv-toggle-control etc.) via :root[data-cv-theme='dark'].
-  // colorSchemeStore is already initialised by AppRuntime before UIRoot mounts
-  // and handles 'auto' (matchMedia) internally.
+  // Always setAttribute (not removeAttribute) on transitions to avoid a brief FOUC gap.
+  // colorSchemeStore handles 'auto' via matchMedia and is initialised before UIRoot mounts.
   $effect(() => {
-    if (colorSchemeStore.isDark) {
-      document.documentElement.setAttribute('data-cv-theme', 'dark');
-    } else {
-      document.documentElement.removeAttribute('data-cv-theme');
-    }
+    document.documentElement.setAttribute('data-cv-theme', colorSchemeStore.isDark ? 'dark' : 'light');
     return () => document.documentElement.removeAttribute('data-cv-theme');
   });
 
@@ -158,7 +152,7 @@
 </div>
 
 <style>
-  /* Light Theme Defaults — on :root so on-page custom elements (cv-toggle-control etc.) inherit them */
+  /* --cv-* defaults (light) — on :root so custom properties cascade into all shadow DOM */
   :global(:root) {
     --cv-bg: white;
     --cv-text: rgba(0, 0, 0, 0.9);
@@ -225,7 +219,7 @@
     --cv-section-label-transform: uppercase;
   }
 
-  /* Root should allow clicks to pass through to the page unless hitting checking/interactive element */
+  /* Fixed zero-size overlay — pointer-events none so clicks pass through to the page */
   :global(.cv-widget-root) {
     position: fixed;
     top: 0;
@@ -233,18 +227,18 @@
     width: 0;
     height: 0;
     z-index: 9999;
-    pointer-events: none; /* Crucial: Allow clicks to pass through */
-    font-family: inherit; /* Inherit font from host */
+    pointer-events: none;
+    font-family: inherit;
   }
 
-  /* But interactive children need pointer-events back */
+  /* Interactive children need pointer-events restored */
   :global(.cv-widget-root > *) {
     pointer-events: auto;
   }
 
-  /* Exception: ShareOverlay manages its own pointer events */
+  /* ShareOverlay manages its own pointer-events internally */
   :global(.cv-widget-root .cv-share-overlay) {
-    pointer-events: none; /* Overlay often passes clicks until specialized handles active */
+    pointer-events: none;
   }
 
   :global(.cv-hidden) {

--- a/src/lib/app/types.ts
+++ b/src/lib/app/types.ts
@@ -14,7 +14,7 @@ export interface RuntimeCallbacks {
   persistenceManager: PersistenceManager;
 }
 
-export interface UIManagerOptions extends Omit<WidgetSettings, 'enabled'> {
+export interface UIManagerOptions extends Omit<WidgetSettings, 'enabled' | 'panel'> {
   /** Callbacks from the runtime for persistence and reset */
   callbacks: RuntimeCallbacks;
 

--- a/src/lib/app/types.ts
+++ b/src/lib/app/types.ts
@@ -31,7 +31,6 @@ export type ResolvedUIManagerOptions = Omit<
 > & {
   container: HTMLElement;
   settingsEnabled: boolean;
-  theme: 'light' | 'dark';
   callout: Required<Pick<WidgetCalloutConfig, 'show' | 'message' | 'enablePulse'>> & {
     backgroundColor?: string | undefined;
     textColor?: string | undefined;

--- a/src/lib/app/ui-manager.ts
+++ b/src/lib/app/ui-manager.ts
@@ -23,7 +23,6 @@ export class CustardUIManager {
       callbacks: options.callbacks,
       container: options.container || document.body,
       settingsEnabled: options.settingsEnabled ?? false,
-      theme: options.panel?.theme || 'light',
       callout: {
         show: options.callout?.show ?? false,
         message: options.callout?.message || 'Customize your reading experience here.',

--- a/src/lib/app/ui-manager.ts
+++ b/src/lib/app/ui-manager.ts
@@ -18,7 +18,6 @@ export class CustardUIManager {
   private options: ResolvedUIManagerOptions;
 
   constructor(options: UIManagerOptions) {
-    // Set defaults
     this.options = {
       callbacks: options.callbacks,
       container: options.container || document.body,
@@ -49,12 +48,10 @@ export class CustardUIManager {
       return;
     }
 
-    // Map context dependency injection directly into app root
     const rootContext = new Map();
     rootContext.set(ICON_SETTINGS_CTX, this.options.callbacks.iconSettings);
     rootContext.set(RUNTIME_CALLBACKS_CTX, this.options.callbacks);
 
-    // Mount Svelte App using Svelte 5 API
     this.app = mount(UIRoot, {
       target: this.options.container,
       props: {
@@ -82,7 +79,9 @@ export function initUIManager(
   runtime: AppRuntime,
   config: ConfigFile,
 ): CustardUIManager | undefined {
-  const { enabled, ...widgetSettings } = config.settings ?? {};
+  // panel settings (title, description, showTabGroups, showReset) are consumed
+  // exclusively by AppRuntime.initStores() — CustardUIManager only needs callout + icon.
+  const { enabled, panel: _panel, ...managerSettings } = config.settings ?? {};
   const settingsEnabled = enabled === true;
 
   const callbacks: RuntimeCallbacks = {
@@ -94,7 +93,7 @@ export function initUIManager(
   const uiManager = new CustardUIManager({
     callbacks,
     settingsEnabled,
-    ...widgetSettings,
+    ...managerSettings,
   });
   uiManager.render();
   return uiManager;

--- a/src/lib/features/settings/ToggleItem.svelte
+++ b/src/lib/features/settings/ToggleItem.svelte
@@ -43,6 +43,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.75rem;
+    gap: 0.75rem;
   }
 
   .title {

--- a/src/lib/features/settings/types.ts
+++ b/src/lib/features/settings/types.ts
@@ -10,8 +10,6 @@ export interface WidgetPanelConfig {
   showTabGroups?: boolean;
   /** Whether to show reset button */
   showReset?: boolean;
-  /** Widget theme */
-  theme?: 'light' | 'dark';
 }
 
 /**

--- a/src/lib/stores/color-scheme-store.svelte.ts
+++ b/src/lib/stores/color-scheme-store.svelte.ts
@@ -1,7 +1,11 @@
 /**
- * App-wide store for color scheme preference.
- * Drives light/dark variant resolution for shorthand label colors and any other
- * components that need to react to the site's color scheme setting.
+ * App-wide store for the site's color scheme preference.
+ * 
+ * Drives the `data-cv-theme` attribute on `<html>` (via UIRoot), which cascades
+ * `--cv-*` CSS custom properties to all CustardUI elements (e.g. settings widget,
+ * modal, on-page custom elements such as `<cv-toggle-control>`).
+ * 
+ * Also used for light/dark variant resolution in label colour logic.
  */
 export class ColorSchemeStore {
   isDark = $state(false);

--- a/src/lib/stores/color-scheme-store.svelte.ts
+++ b/src/lib/stores/color-scheme-store.svelte.ts
@@ -5,7 +5,7 @@
  * `--cv-*` CSS custom properties to all CustardUI elements (e.g. settings widget,
  * modal, on-page custom elements such as `<cv-toggle-control>`).
  * 
- * Also used for light/dark variant resolution in label colour logic.
+ * Also used for light/dark variant resolution in label color logic.
  */
 export class ColorSchemeStore {
   isDark = $state(false);


### PR DESCRIPTION
**Overview of changes:**

Work part of #224

* Update `colorScheme` documentation to indicate it controls all CustardUI elements.
* deprecates `panel.theme` setting, which is not currently depended on by external users, hence leaving it as `patch`. It is intended.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)


**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [ ] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:
- [x] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
