### PR TITLE
Add inline attribute to Toggle component

### DIFF
--- a/docs/authorGuide/components/toggles.md
+++ b/docs/authorGuide/components/toggles.md
@@ -98,11 +98,36 @@ A toggle can also be shown or hidden based on whether a [placeholder](./placehol
 The block is hidden when `username` has no value, and visible when it does. See [Placeholder-Driven Toggles](./placeholders.md#placeholder-driven-toggles) for full details.
 
 
+### Inline Toggles
+
+By default, `<cv-toggle>` elements behave as block-level elements (`display: block`). If you want to render a toggle or a placeholder-driven toggle inline (for example, to display a conditional badge or inline text within a paragraph or navigation link), add the `inline` attribute.
+
+* This displays any toggle content inline so it flows with surrounding text without a line break.
+
+<cv-toggle-control toggle-id="mac"></cv-toggle-control>
+<cv-placeholder-input name="username" layout="card"></cv-placeholder-input>
+
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
+
+Run the configuration commands <cv-toggle inline toggle-id="mac">
+for **macOS**</cv-toggle> in your terminal.
+
+<cv-toggle inline placeholder-id="username"> Welcome back! </cv-toggle>
+
+</variable>
+</include>
+
+
+
 ### Attributes of `<cv-toggle>`
 
 | Name     | Type      | Default      | Description                    |
 | -------- | --------- | ------------ | ------------------------------ |
 | toggle-id        | `string`  | **required** | Defines the category for the cv-toggle element. E.g.: `toggle-id="mac"`. |
+| placeholder-id   | `string`  | —            | If set, drives the toggle visibility by whether the named placeholder has a value. Cannot be used together with toggle-id. |
+| inline           | `boolean` | `false`      | If present, renders the toggle and its internal wrappers inline (`display: inline`) so it flows seamlessly with surrounding text instead of creating block-level line breaks. |
 | show-peek-border | `boolean` | `false`      | If present, adds a subtle border to the top and sides of the toggle content. The border is only applied while the toggle is in Peek mode (whether collapsed or user‑expanded). When the toggle is fully shown (non‑Peek), no border is rendered even if this attribute is set. |
 | show-label       | `boolean` | `false`      | If present, displays the category label (e.g. "MacOS") at the top-left corner of the toggle. |
 

--- a/docs/authorGuide/components/toggles.md
+++ b/docs/authorGuide/components/toggles.md
@@ -103,6 +103,7 @@ The block is hidden when `username` has no value, and visible when it does. See 
 By default, `<cv-toggle>` elements behave as block-level elements (`display: block`). If you want to render a toggle or a placeholder-driven toggle inline (for example, to display a conditional badge or inline text within a paragraph or navigation link), add the `inline` attribute.
 
 * This displays any toggle content inline so it flows with surrounding text without a line break.
+* Note that inline toggles do not support peek/expand mode, and will simply be shown in full when peek/show states are active.
 
 <cv-toggle-control toggle-id="mac"></cv-toggle-control>
 <cv-placeholder-input name="username" layout="card"></cv-placeholder-input>

--- a/src/lib/features/toggles/components/Toggle.svelte
+++ b/src/lib/features/toggles/components/Toggle.svelte
@@ -6,6 +6,7 @@
       showPeekBorder: { reflect: true, type: 'Boolean', attribute: 'show-peek-border' },
       showLabel: { reflect: true, type: 'Boolean', attribute: 'show-label' },
       placeholderId: { reflect: true, type: 'String', attribute: 'placeholder-id' },
+      inline: { reflect: true, type: 'Boolean', attribute: 'inline' },
     },
   }}
 />
@@ -23,15 +24,19 @@
     showPeekBorder = false,
     showLabel = false,
     placeholderId = '',
+    inline = false,
   }: {
     toggleId?: string;
     showPeekBorder?: boolean;
     showLabel?: boolean;
     placeholderId?: string;
+    inline?: boolean;
   } = $props();
   // Derive toggle IDs from toggle-id prop (can have multiple space-separated IDs)
   let toggleIds = $derived((toggleId || '').split(/\s+/).filter(Boolean));
-  let toggleConfig = $derived(activeStateStore.config.toggles?.find((t) => t.toggleId === toggleIds[0]));
+  let toggleConfig = $derived(
+    activeStateStore.config.toggles?.find((t) => t.toggleId === toggleIds[0]),
+  );
 
   $effect(() => {
     toggleIds.forEach((id) => elementStore.registerToggle(id));
@@ -167,8 +172,6 @@
     e.stopPropagation();
     localExpanded = !localExpanded;
   }
-
-
 </script>
 
 <div
@@ -178,6 +181,7 @@
   class:peek-mode={peekState && !isSmallContent}
   class:hidden={isHidden}
   class:has-border={showPeekBorder && peekState}
+  class:inline-mode={inline}
 >
   {#if showLabel && labelText && !isHidden}
     <div class="cv-toggle-label">{labelText}</div>
@@ -220,6 +224,12 @@
     overflow: visible;
   }
 
+  /* Inline mode: renders the host as inline so it flows with surrounding text */
+  :host([inline]) {
+    display: inline;
+    vertical-align: baseline;
+  }
+
   /* Host visibility control */
   :host([hidden]) {
     display: none;
@@ -232,8 +242,25 @@
     margin-bottom: 4px;
   }
 
+  /* In inline mode, don't force block-level width or margins */
+  .cv-toggle-wrapper.inline-mode {
+    display: inline;
+    width: auto;
+    margin-bottom: 0;
+    vertical-align: baseline;
+  }
+
+  .cv-toggle-wrapper.inline-mode .cv-toggle-content,
+  .cv-toggle-wrapper.inline-mode .cv-toggle-inner {
+    display: inline;
+  }
+
   .cv-toggle-wrapper.hidden {
     margin-bottom: 0;
+  }
+
+  .cv-toggle-wrapper.hidden.inline-mode {
+    display: none;
   }
 
   .cv-toggle-wrapper.peek-mode {
@@ -293,8 +320,13 @@
   /* Peek State — smoother gradient */
   .peeking .cv-toggle-content {
     opacity: 1;
-    mask-image: linear-gradient(to bottom, black 30%, rgba(0,0,0,0.5) 70%, transparent 100%);
-    -webkit-mask-image: linear-gradient(to bottom, black 30%, rgba(0,0,0,0.5) 70%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 30%, rgba(0, 0, 0, 0.5) 70%, transparent 100%);
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      black 30%,
+      rgba(0, 0, 0, 0.5) 70%,
+      transparent 100%
+    );
   }
 
   /* Label Style */


### PR DESCRIPTION
**Overview of changes:**

Fixes #232 by adding inline attribute to toggles so they are displayed inline. Instead of block display.

See https://custardui.js.org/devdocs/authorGuide/components/toggles.html#toggles for documentation.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [x] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)


**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:
- [x] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
