### PR TITLE
Add more input sanitization

### DIFF
--- a/docs/authorGuide/components/placeholders.md
+++ b/docs/authorGuide/components/placeholders.md
@@ -220,11 +220,11 @@ Interpolate placeholder values into HTML attributes such as `href` or `src` by a
 
 **Security and Responsible Use**
 
-Placeholders can be populated directly from [shareable URL parameters](#shareable-url). They must be treated as **untrusted user input**. 
+Placeholders can be populated directly from [shareable URL parameters](#shareable-url). They must be treated as **untrusted user input**.
 
-- **Cross-Site Scripting (XSS):** While CustardUI automatically URL-encodes placeholder values when they are used as components of an `href` or `src` attribute (e.g. `[[username]]`), it **does not** prevent full `javascript:` URLs if the placeholder itself is a full URL.
-- **Avoid Dangerous Attributes:** Never bind placeholders to event handler attributes (e.g., `onclick`, `onerror`, `onmouseover`) or `<script>` tags, as they are not sanitized and could execute arbitrary code if a malicious shareable URL is clicked.
-- **Context Awareness:** Only bind placeholders to attributes where the resulting value is constrained to a safe domain or format that you control.
+- **Protocol blocking:** `javascript:` and `vbscript:` URLs are blocked when a placeholder value is bound to an `href` or `src` attribute, returning an empty string instead.
+- **Event handler blocking:** Placeholder binding into `on*` attributes (e.g. `onclick`, `onerror`) is blocked entirely, the attribute is silently skipped and a warning is logged to the console.
+- **Context awareness:** Only bind placeholders to attributes where the resulting value is constrained to a safe domain or format that you control.
 
 </box>
 

--- a/docs/authorGuide/components/placeholders.md
+++ b/docs/authorGuide/components/placeholders.md
@@ -223,7 +223,7 @@ Interpolate placeholder values into HTML attributes such as `href` or `src` by a
 Placeholders can be populated directly from [shareable URL parameters](#shareable-url). They must be treated as **untrusted user input**.
 
 - **Protocol blocking:** `javascript:` and `vbscript:` URLs are blocked when a placeholder value is bound to an `href` or `src` attribute, returning an empty string instead.
-- **Event handler blocking:** Placeholder binding into `on*` attributes (e.g. `onclick`, `onerror`) is blocked entirely, the attribute is silently skipped and a warning is logged to the console.
+- **Event handler blocking:** Placeholder binding into `on*` attributes (e.g. `onclick`, `onerror`) is blocked entirely, and the attribute is silently skipped and a warning is logged to the console.
 - **Context awareness:** Only bind placeholders to attributes where the resulting value is constrained to a safe domain or format that you control.
 
 </box>

--- a/src/lib/features/adaptation/adaptation-manager.ts
+++ b/src/lib/features/adaptation/adaptation-manager.ts
@@ -137,7 +137,21 @@ export class AdaptationManager {
 
     // Inject CSS variables onto :root
     if (theme.cssVariables) {
+      const CUSTOM_PROP = /^--[a-zA-Z0-9_-]+$/;
+      const DANGEROUS_VALUE = /url\s*\(|expression\s*\(|javascript:/i;
       for (const [property, value] of Object.entries(theme.cssVariables)) {
+        if (!CUSTOM_PROP.test(property)) {
+          console.warn(
+            `[CustardUI] Ignoring non-custom CSS property in adaptation theme: "${property}"`,
+          );
+          continue;
+        }
+        if (DANGEROUS_VALUE.test(value)) {
+          console.warn(
+            `[CustardUI] Ignoring suspicious CSS value for "${property}" in adaptation theme.`,
+          );
+          continue;
+        }
         document.documentElement.style.setProperty(property, value);
       }
     }

--- a/src/lib/features/placeholder/placeholder-binder.ts
+++ b/src/lib/features/placeholder/placeholder-binder.ts
@@ -199,11 +199,16 @@ export class PlaceholderBinder {
         try {
           const templates = JSON.parse(el.dataset.cvAttrTemplates || '{}');
           Object.entries(templates).forEach(([attrName, template]) => {
-            const newValue = PlaceholderBinder.interpolateString(
+            let newValue = PlaceholderBinder.interpolateString(
               template as string,
               values,
               attrName,
             );
+            if (attrName === 'href' || attrName === 'src') {
+              if (PlaceholderBinder.isDangerousProtocol(newValue)) {
+                newValue = '';
+              }
+            }
             el.setAttribute(attrName, newValue);
           });
         } catch (e) {

--- a/src/lib/features/placeholder/placeholder-binder.ts
+++ b/src/lib/features/placeholder/placeholder-binder.ts
@@ -212,6 +212,14 @@ export class PlaceholderBinder {
   }
 
   /**
+   * Checks if a value uses a dangerous URL protocol that could execute scripts.
+   * Must be tested BEFORE isFullUrl, which would otherwise let these pass through.
+   */
+  private static isDangerousProtocol(value: string): boolean {
+    return /^\s*(javascript|vbscript):/i.test(value);
+  }
+
+  /**
    * Checks if a value is a relative URL path (e.g., /, ./, ../)
    */
   private static isRelativeUrl(value: string): boolean {
@@ -300,6 +308,7 @@ export class PlaceholderBinder {
           if (val === undefined) return ifUnset ?? '';
           // URL-encode the value component (same as regular placeholders)
           if (attrName && (attrName === 'href' || attrName === 'src')) {
+            if (PlaceholderBinder.isDangerousProtocol(val)) return '';
             if (!PlaceholderBinder.isFullUrl(val) && !PlaceholderBinder.isRelativeUrl(val)) {
               val = encodeURIComponent(val);
             }
@@ -312,6 +321,8 @@ export class PlaceholderBinder {
 
         // Context-aware encoding for URL attributes
         if (attrName && (attrName === 'href' || attrName === 'src')) {
+          // Block dangerous protocols before any further URL handling
+          if (PlaceholderBinder.isDangerousProtocol(val)) return '';
           // Don't encode full URLs or relative URLs - only encode URL components
           if (!PlaceholderBinder.isFullUrl(val) && !PlaceholderBinder.isRelativeUrl(val)) {
             val = encodeURIComponent(val);

--- a/src/lib/features/placeholder/placeholder-binder.ts
+++ b/src/lib/features/placeholder/placeholder-binder.ts
@@ -77,7 +77,7 @@ export class PlaceholderBinder {
     // Attribute Scanning (Opt-in)
     const candidates = root.querySelectorAll('.cv-bind, [data-cv-bind]');
     candidates.forEach((el) => {
-      if (el instanceof HTMLElement) {
+      if (el instanceof Element) {
         PlaceholderBinder.processElementAttributes(el);
       }
     });
@@ -138,8 +138,8 @@ export class PlaceholderBinder {
     }
   }
 
-  private static processElementAttributes(el: HTMLElement) {
-    if (el.dataset.cvAttrTemplates) return; // Already processed
+  private static processElementAttributes(el: Element) {
+    if (el.hasAttribute('data-cv-attr-templates')) return; // Already processed
 
     const templates: Record<string, string> = {};
     let hasBindings = false;
@@ -174,7 +174,7 @@ export class PlaceholderBinder {
     }
 
     if (hasBindings) {
-      el.dataset.cvAttrTemplates = JSON.stringify(templates);
+      el.setAttribute('data-cv-attr-templates', JSON.stringify(templates));
 
       const matcher = new RegExp(VAR_REGEX.source, 'g');
       Object.values(templates).forEach((tmpl) => {
@@ -196,16 +196,16 @@ export class PlaceholderBinder {
   private static updateAttributeBindings(values: Record<string, string>) {
     const attrElements = document.querySelectorAll('[data-cv-attr-templates]');
     attrElements.forEach((el) => {
-      if (el instanceof HTMLElement) {
+      if (el instanceof Element) {
         try {
-          const templates = JSON.parse(el.dataset.cvAttrTemplates || '{}');
+          const templates = JSON.parse(el.getAttribute('data-cv-attr-templates') || '{}');
           Object.entries(templates).forEach(([attrName, template]) => {
             let newValue = PlaceholderBinder.interpolateString(
               template as string,
               values,
               attrName,
             );
-            if (attrName === 'href' || attrName === 'src') {
+            if (attrName && /(^|:)(href|src|action|formaction)$/i.test(attrName)) {
               if (hasDangerousProtocol(newValue)) {
                 newValue = '';
               }
@@ -317,7 +317,7 @@ export class PlaceholderBinder {
               : PlaceholderBinder.resolveUserValue(name, values);
           if (val === undefined) return ifUnset ?? '';
           // URL-encode the value component (same as regular placeholders)
-          if (attrName && (attrName === 'href' || attrName === 'src')) {
+          if (attrName && /(^|:)(href|src|action|formaction)$/i.test(attrName)) {
             if (hasDangerousProtocol(val)) return '';
             if (!PlaceholderBinder.isFullUrl(val) && !PlaceholderBinder.isRelativeUrl(val)) {
               val = encodeURIComponent(val);
@@ -330,7 +330,7 @@ export class PlaceholderBinder {
         if (val === undefined) return `[[${name}]]`;
 
         // Context-aware encoding for URL attributes
-        if (attrName && (attrName === 'href' || attrName === 'src')) {
+        if (attrName && /(^|:)(href|src|action|formaction)$/i.test(attrName)) {
           // Block dangerous protocols before any further URL handling
           if (hasDangerousProtocol(val)) return '';
           // Don't encode full URLs or relative URLs - only encode URL components

--- a/src/lib/features/placeholder/placeholder-binder.ts
+++ b/src/lib/features/placeholder/placeholder-binder.ts
@@ -20,6 +20,7 @@ const VAR_TESTER =
 
 import { placeholderRegistryStore } from '$features/placeholder/stores/placeholder-registry-store.svelte';
 import { elementStore } from '$lib/stores/element-store.svelte';
+import { hasDangerousProtocol } from '$lib/utils/url-utils';
 
 export class PlaceholderBinder {
   /**
@@ -205,7 +206,7 @@ export class PlaceholderBinder {
               attrName,
             );
             if (attrName === 'href' || attrName === 'src') {
-              if (PlaceholderBinder.isDangerousProtocol(newValue)) {
+              if (hasDangerousProtocol(newValue)) {
                 newValue = '';
               }
             }
@@ -226,14 +227,6 @@ export class PlaceholderBinder {
     // Match protocol://... OR protocol: (for mailto:, data:, tel:, etc.)
     // Protocol must start with letter per RFC 3986
     return /^[a-z][a-z0-9+.-]*:/i.test(value);
-  }
-
-  /**
-   * Checks if a value uses a dangerous URL protocol that could execute scripts.
-   * Must be tested BEFORE isFullUrl, which would otherwise let these pass through.
-   */
-  private static isDangerousProtocol(value: string): boolean {
-    return /^\s*(javascript|vbscript):/i.test(value);
   }
 
   /**
@@ -325,7 +318,7 @@ export class PlaceholderBinder {
           if (val === undefined) return ifUnset ?? '';
           // URL-encode the value component (same as regular placeholders)
           if (attrName && (attrName === 'href' || attrName === 'src')) {
-            if (PlaceholderBinder.isDangerousProtocol(val)) return '';
+            if (hasDangerousProtocol(val)) return '';
             if (!PlaceholderBinder.isFullUrl(val) && !PlaceholderBinder.isRelativeUrl(val)) {
               val = encodeURIComponent(val);
             }
@@ -339,7 +332,7 @@ export class PlaceholderBinder {
         // Context-aware encoding for URL attributes
         if (attrName && (attrName === 'href' || attrName === 'src')) {
           // Block dangerous protocols before any further URL handling
-          if (PlaceholderBinder.isDangerousProtocol(val)) return '';
+          if (hasDangerousProtocol(val)) return '';
           // Don't encode full URLs or relative URLs - only encode URL components
           if (!PlaceholderBinder.isFullUrl(val) && !PlaceholderBinder.isRelativeUrl(val)) {
             val = encodeURIComponent(val);

--- a/src/lib/features/placeholder/placeholder-binder.ts
+++ b/src/lib/features/placeholder/placeholder-binder.ts
@@ -154,6 +154,18 @@ export class PlaceholderBinder {
         continue;
       }
 
+      // Block placeholder binding into event handler attributes (on*).
+      // The entire value of an event handler is a script execution context —
+      // there is no safe way to interpolate untrusted user input into it.
+      if (/^on/i.test(attr.name)) {
+        if (VAR_TESTER.test(attr.value)) {
+          console.warn(
+            `[CustardUI] Placeholder binding into event handler attribute "${attr.name}" is blocked for security. Remove the placeholder from this attribute.`,
+          );
+        }
+        continue;
+      }
+
       if (VAR_TESTER.test(attr.value)) {
         templates[attr.name] = attr.value;
         hasBindings = true;

--- a/src/lib/features/tabs/components/TabGroup.svelte
+++ b/src/lib/features/tabs/components/TabGroup.svelte
@@ -46,6 +46,20 @@
     return groupId && tabs$[groupId] ? tabs$[groupId] : null;
   });
 
+  // Precompute tab active/marked states reactively to avoid template {@const} preprocessor bugs
+  let derivedTabs = $derived.by(() => {
+    return tabs.map((tab) => {
+      const splitIds = splitTabIds(tab.rawId);
+      const isActive = splitIds.includes(localActiveTabId);
+      const isMarked = !!(markedTab && splitIds.includes(markedTab));
+      return {
+        ...tab,
+        isActive,
+        isMarked,
+      };
+    });
+  });
+
   // Track the last seen store state to detect real changes
   let lastSeenStoreState = $state<string | null>(null);
 
@@ -89,6 +103,40 @@
       .map((id) => id.trim());
   }
 
+  /**
+   * Sanitizes HTML sourced from cv-tab-header innerHTML.
+   * Strips script, style, link, and all inline event handler attributes
+   * (on*) and javascript: hrefs/srcs, preserving safe rich formatting.
+   * Uses DOMParser — no external dependencies.
+   */
+  function sanitizeTabHeader(rawHtml: string): string {
+    const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
+
+    // Remove entirely unsafe elements
+    doc
+      .querySelectorAll('script, style, link, object, embed, iframe, form')
+      .forEach((el) => el.remove());
+
+    // Walk all remaining elements and strip dangerous attributes
+    doc.body.querySelectorAll('*').forEach((el) => {
+      for (const attr of Array.from(el.attributes)) {
+        // Strip all on* event handler attributes
+        if (/^on/i.test(attr.name)) {
+          el.removeAttribute(attr.name);
+          continue;
+        }
+        // Strip javascript: / vbscript: / data: from href and src
+        if (attr.name === 'href' || attr.name === 'src' || attr.name === 'action') {
+          if (/^\s*(javascript|vbscript|data):/i.test(attr.value)) {
+            el.removeAttribute(attr.name);
+          }
+        }
+      }
+    });
+
+    return doc.body.innerHTML;
+  }
+
   // Todo: For handleSlotChange(), consider if there is a svelte way
   // to do this without the need for the slotchange event.
 
@@ -124,15 +172,17 @@
       // Check for <cv-tab-header>
       const headerEl = element.querySelector('cv-tab-header');
       if (headerEl) {
-        header = headerEl.innerHTML.trim();
+        header = sanitizeTabHeader(headerEl.innerHTML.trim());
       } else {
-        // Attribute syntax
-        header =
+        // Attribute syntax — also supports raw HTML (e.g. <i> icons), so sanitize too
+        const rawAttrHeader =
           (element as HTMLElement & { header?: string }).header ||
           element.getAttribute('header') ||
           '';
 
-        if (!header) {
+        if (rawAttrHeader) {
+          header = sanitizeTabHeader(rawAttrHeader);
+        } else {
           // Fallback to tab-id or default
           header = element.getAttribute('tab-id') ? primaryId : `Tab ${index + 1}`;
         }
@@ -241,18 +291,15 @@
   <!-- Nav -->
   {#if tabs.length > 0 && navHeadingVisible}
     <ul class="cv-tabgroup-nav" role="tablist">
-      {#each tabs as tab (tab.id)}
-        {@const splitIds = splitTabIds(tab.rawId)}
-        {@const isActive = splitIds.includes(localActiveTabId)}
-        {@const isMarked = markedTab && splitIds.includes(markedTab)}
+      {#each derivedTabs as tab (tab.id)}
         <li class="cv-tabgroup-item">
-          <div class="cv-tab-wrapper" class:active={isActive}>
+          <div class="cv-tab-wrapper" class:active={tab.isActive}>
             <a
               class="cv-tabgroup-link"
               href={'#' + tab.id}
-              class:active={isActive}
+              class:active={tab.isActive}
               role="tab"
-              aria-selected={isActive}
+              aria-selected={tab.isActive}
               onclick={(e) => handleTabClick(tab.id, e)}
               ondblclick={(e) => handleTabDoubleClick(tab.id, e)}
               title="Double-click a tab to 'mark' it in all similar tab groups."
@@ -266,16 +313,16 @@
             <button
               type="button"
               class="cv-tab-marked-icon"
-              class:is-marked={isMarked}
-              title={isMarked ? 'Unmark this tab' : 'Mark this tab'}
-              aria-label={isMarked ? 'Unmark this tab' : 'Mark this tab'}
-              aria-pressed={!!isMarked}
+              class:is-marked={tab.isMarked}
+              title={tab.isMarked ? 'Unmark this tab' : 'Mark this tab'}
+              aria-label={tab.isMarked ? 'Unmark this tab' : 'Mark this tab'}
+              aria-pressed={tab.isMarked}
               onclick={(e) => handleMarkClick(tab.id, e)}
               ondblclick={(e) => {
                 e.stopPropagation();
               }}
             >
-              <IconMark {isMarked} />
+              <IconMark isMarked={tab.isMarked} />
             </button>
           </div>
         </li>

--- a/src/lib/features/tabs/components/TabGroup.svelte
+++ b/src/lib/features/tabs/components/TabGroup.svelte
@@ -104,13 +104,6 @@
       .map((id) => id.trim());
   }
 
-  /**
-   * Sanitizes HTML sourced from cv-tab-header innerHTML.
-   * Strips script, style, link, and all inline event handler attributes
-   * (on*) and javascript: hrefs/srcs, preserving safe rich formatting.
-   * Uses DOMParser — no external dependencies.
-   */
-
   // Todo: For handleSlotChange(), consider if there is a svelte way
   // to do this without the need for the slotchange event.
 

--- a/src/lib/features/tabs/components/TabGroup.svelte
+++ b/src/lib/features/tabs/components/TabGroup.svelte
@@ -15,6 +15,7 @@
   import { elementStore } from '$lib/stores/element-store.svelte';
   import { uiStore } from '$lib/stores/ui-store.svelte';
   import { captureScrollAnchor, restoreScrollAnchor } from '$lib/utils/scroll-utils';
+  import { sanitizeTabHeader } from '$lib/utils/url-utils';
 
   //  ID of the tabgroup Group
   let { groupId, stabilizeScroll = true } = $props<{
@@ -109,33 +110,6 @@
    * (on*) and javascript: hrefs/srcs, preserving safe rich formatting.
    * Uses DOMParser — no external dependencies.
    */
-  function sanitizeTabHeader(rawHtml: string): string {
-    const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
-
-    // Remove entirely unsafe elements
-    doc
-      .querySelectorAll('script, style, link, object, embed, iframe, form')
-      .forEach((el) => el.remove());
-
-    // Walk all remaining elements and strip dangerous attributes
-    doc.body.querySelectorAll('*').forEach((el) => {
-      for (const attr of Array.from(el.attributes)) {
-        // Strip all on* event handler attributes
-        if (/^on/i.test(attr.name)) {
-          el.removeAttribute(attr.name);
-          continue;
-        }
-        // Strip javascript: / vbscript: / data: from href and src
-        if (attr.name === 'href' || attr.name === 'src' || attr.name === 'action') {
-          if (/^\s*(javascript|vbscript|data):/i.test(attr.value)) {
-            el.removeAttribute(attr.name);
-          }
-        }
-      }
-    });
-
-    return doc.body.innerHTML;
-  }
 
   // Todo: For handleSlotChange(), consider if there is a svelte way
   // to do this without the need for the slotchange event.

--- a/src/lib/utils/url-utils.ts
+++ b/src/lib/utils/url-utils.ts
@@ -61,9 +61,9 @@ export function sanitizeTabHeader(rawHtml: string): string {
         el.removeAttribute(attr.name);
         continue;
       }
-      // Strip javascript: / vbscript: / data: from href, src, and action
+      // Strip javascript: / vbscript: / data: from URL-bearing attributes (literal or namespaced, e.g. href, xlink:href, src, action)
       // Also handles bypasses where control/whitespace characters are embedded (e.g. ja\tvascript:)
-      if (attr.name === 'href' || attr.name === 'src' || attr.name === 'action') {
+      if (/(^|:)(href|src|action|formaction)$/i.test(attr.name)) {
         if (hasDangerousProtocol(attr.value, ['javascript', 'vbscript', 'data'])) {
           el.removeAttribute(attr.name);
         }

--- a/src/lib/utils/url-utils.ts
+++ b/src/lib/utils/url-utils.ts
@@ -18,3 +18,58 @@ export function prependBaseUrl(path: string, baseUrl: string): string {
 
   return cleanbaseUrl + cleanPath;
 }
+
+/**
+ * Checks if a URL value starts with any of the specified dangerous protocols.
+ * Strips all ASCII control and whitespace characters before matching to prevent bypasses.
+ */
+export function hasDangerousProtocol(
+  value: string,
+  blockedProtocols: string[] = ['javascript', 'vbscript'],
+): boolean {
+  // eslint-disable-next-line no-control-regex
+  const normalized = value.replace(/[\x00-\x1F\x7F\s]/g, '');
+  const pattern = new RegExp(`^(${blockedProtocols.join('|')}):`, 'i');
+  return pattern.test(normalized);
+}
+
+/**
+ * Sanitizes HTML sourced from cv-tab-header innerHTML or header attribute.
+ * Strips script, style, link, and all inline event handler attributes (on*)
+ * and javascript:/vbscript:/data: URLs from href/src/action, preserving safe rich formatting.
+ * Uses DOMParser — no external dependencies.
+ */
+export function sanitizeTabHeader(rawHtml: string): string {
+  if (typeof DOMParser === 'undefined') {
+    // Return rawHtml if DOMParser is not available (e.g., SSR or node context without jsdom),
+    // though in our actual runtime it's browser-only.
+    return rawHtml;
+  }
+
+  const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
+
+  // Remove entirely unsafe elements
+  doc
+    .querySelectorAll('script, style, link, object, embed, iframe, form')
+    .forEach((el) => el.remove());
+
+  // Walk all remaining elements and strip dangerous attributes
+  doc.body.querySelectorAll('*').forEach((el) => {
+    for (const attr of Array.from(el.attributes)) {
+      // Strip all on* event handler attributes
+      if (/^on/i.test(attr.name)) {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+      // Strip javascript: / vbscript: / data: from href, src, and action
+      // Also handles bypasses where control/whitespace characters are embedded (e.g. ja\tvascript:)
+      if (attr.name === 'href' || attr.name === 'src' || attr.name === 'action') {
+        if (hasDangerousProtocol(attr.value, ['javascript', 'vbscript', 'data'])) {
+          el.removeAttribute(attr.name);
+        }
+      }
+    }
+  });
+
+  return doc.body.innerHTML;
+}

--- a/tests/lib/features/adaptation/adaptation-manager.test.ts
+++ b/tests/lib/features/adaptation/adaptation-manager.test.ts
@@ -436,4 +436,86 @@ describe('AdaptationManager', () => {
       expect(document.querySelectorAll('link[data-cv-adaptation-id="css-id"]').length).toBe(1);
     });
   });
+
+  // ===========================================================================
+  // Security: CSS variable validation
+  // ===========================================================================
+
+  describe('Security — CSS variable validation in applyTheme()', () => {
+    const mockAdaptWith = (cssVariables: Record<string, string>) => {
+      mockLocation('http://localhost/?adapt=sec-id');
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'sec-id', theme: { cssVariables } }),
+      });
+    };
+
+    it('rejects non-custom-property keys (no -- prefix)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAdaptWith({ color: 'red' });
+
+      await AdaptationManager.init();
+
+      expect(document.documentElement.style.getPropertyValue('color')).toBe('');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('non-custom CSS property'));
+    });
+
+    it('rejects keys with injection characters (e.g. semicolons)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAdaptWith({ '--good; --evil': 'red' });
+
+      await AdaptationManager.init();
+
+      expect(document.documentElement.style.getPropertyValue('--good')).toBe('');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('non-custom CSS property'));
+    });
+
+    it('rejects values containing url()', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAdaptWith({ '--bg': 'url(https://evil.com/track.gif)' });
+
+      await AdaptationManager.init();
+
+      expect(document.documentElement.style.getPropertyValue('--bg')).toBe('');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('suspicious CSS value'));
+    });
+
+    it('rejects values containing expression()', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAdaptWith({ '--size': 'expression(document.cookie)' });
+
+      await AdaptationManager.init();
+
+      expect(document.documentElement.style.getPropertyValue('--size')).toBe('');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('suspicious CSS value'));
+    });
+
+    it('rejects values containing javascript: (case-insensitive)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAdaptWith({ '--font': 'JAVASCRIPT:alert(1)' });
+
+      await AdaptationManager.init();
+
+      expect(document.documentElement.style.getPropertyValue('--font')).toBe('');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('suspicious CSS value'));
+    });
+
+    it('applies valid custom properties and skips invalid ones in the same config', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAdaptWith({
+        '--primary': '#3490dc',
+        badKey: 'shouldBeIgnored',
+        '--danger': 'url(evil.com)',
+        '--secondary': '#ffed4a',
+      });
+
+      await AdaptationManager.init();
+
+      expect(document.documentElement.style.getPropertyValue('--primary')).toBe('#3490dc');
+      expect(document.documentElement.style.getPropertyValue('--secondary')).toBe('#ffed4a');
+      expect(document.documentElement.style.getPropertyValue('badKey')).toBe('');
+      expect(document.documentElement.style.getPropertyValue('--danger')).toBe('');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/tests/lib/features/placeholder/placeholder-binder.test.ts
+++ b/tests/lib/features/placeholder/placeholder-binder.test.ts
@@ -246,6 +246,9 @@ describe('PlaceholderBinder', () => {
       const a = container.querySelector('a')!;
       expect(a.getAttribute('href')).toBe('mailto:support@example.com');
     });
+  });
+
+  describe('updateAll — fallback priority', () => {
     it('should treat an explicit empty fallback as "show nothing" (overrides registry default)', () => {
       vi.mocked(placeholderRegistryStore.get).mockReturnValue({
         name: 'key',

--- a/tests/lib/features/placeholder/placeholder-security.test.ts
+++ b/tests/lib/features/placeholder/placeholder-security.test.ts
@@ -1,8 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PlaceholderBinder } from '../../../../src/lib/features/placeholder/placeholder-binder';
-import { elementStore } from '../../../../src/lib/stores/element-store.svelte';
-import { placeholderRegistryStore } from '../../../../src/lib/features/placeholder/stores/placeholder-registry-store.svelte';
 
 // Mock element store
 vi.mock('../../../../src/lib/stores/element-store.svelte', () => {
@@ -135,6 +133,20 @@ describe('PlaceholderBinder - Security', () => {
       PlaceholderBinder.updateAll({ scheme: 'script:alert(1)' });
 
       // Fully assembled value is "javascript:alert(1)" which should be blocked and set to empty string
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+    });
+
+    it('blocks dangerous protocols with embedded control characters or whitespaces', () => {
+      container.innerHTML = '<a href="[[url]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'java\tscript:alert(1)' });
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+
+      PlaceholderBinder.updateAll({ url: 'java\nscript:alert(1)' });
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+
+      PlaceholderBinder.updateAll({ url: 'java\x01script:alert(1)' });
       expect(container.querySelector('a')!.getAttribute('href')).toBe('');
     });
   });

--- a/tests/lib/features/placeholder/placeholder-security.test.ts
+++ b/tests/lib/features/placeholder/placeholder-security.test.ts
@@ -149,6 +149,22 @@ describe('PlaceholderBinder - Security', () => {
       PlaceholderBinder.updateAll({ url: 'java\x01script:alert(1)' });
       expect(container.querySelector('a')!.getAttribute('href')).toBe('');
     });
+
+    it('blocks dangerous protocols in namespaced SVG xlink:href attributes', () => {
+      container.innerHTML = '<svg><use xlink:href="[[url]]" class="cv-bind"></use></svg>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'javascript:alert(1)' });
+      expect(container.querySelector('use')!.getAttribute('xlink:href')).toBe('');
+    });
+
+    it('blocks dangerous protocols in formaction attributes', () => {
+      container.innerHTML = '<button formaction="[[url]]" class="cv-bind">Go</button>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'javascript:alert(1)' });
+      expect(container.querySelector('button')!.getAttribute('formaction')).toBe('');
+    });
   });
 
   describe('Security — dangerous protocol blocking does not affect template text', () => {

--- a/tests/lib/features/placeholder/placeholder-security.test.ts
+++ b/tests/lib/features/placeholder/placeholder-security.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PlaceholderBinder } from '../../../../src/lib/features/placeholder/placeholder-binder';
+import { elementStore } from '../../../../src/lib/stores/element-store.svelte';
+import { placeholderRegistryStore } from '../../../../src/lib/features/placeholder/stores/placeholder-registry-store.svelte';
+
+// Mock element store
+vi.mock('../../../../src/lib/stores/element-store.svelte', () => {
+  return {
+    elementStore: {
+      registerPlaceholder: vi.fn(),
+    },
+  };
+});
+
+// Mock the store BEFORE importing the subject under test
+vi.mock('../../../../src/lib/features/placeholder/stores/placeholder-registry-store.svelte', () => {
+  return {
+    placeholderRegistryStore: {
+      definitions: [],
+      register: vi.fn(),
+      get: vi.fn(),
+      has: vi.fn(),
+    },
+  };
+});
+
+describe('PlaceholderBinder - Security', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  describe('Security — dangerous protocol blocking in href/src', () => {
+    it('blocks javascript: in a standalone href placeholder', () => {
+      container.innerHTML = '<a href="[[url]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'javascript:alert(1)' });
+
+      const a = container.querySelector('a')!;
+      expect(a.getAttribute('href')).toBe('');
+    });
+
+    it('blocks javascript: (uppercase) in href', () => {
+      container.innerHTML = '<a href="[[url]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'JAVASCRIPT:alert(1)' });
+
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+    });
+
+    it('blocks javascript: with leading whitespace in href', () => {
+      container.innerHTML = '<a href="[[url]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: '  javascript:alert(1)' });
+
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+    });
+
+    it('blocks vbscript: in href', () => {
+      container.innerHTML = '<a href="[[url]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'vbscript:MsgBox(1)' });
+
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+    });
+
+    it('blocks javascript: in a standalone src placeholder', () => {
+      container.innerHTML = '<img src="[[imgurl]]" class="cv-bind" />';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ imgurl: 'javascript:void(0)' });
+
+      expect(container.querySelector('img')!.getAttribute('src')).toBe('');
+    });
+
+    it('does NOT block legitimate data: URIs (e.g. base64 images) in src', () => {
+      container.innerHTML = '<img src="[[dataurl]]" class="cv-bind" />';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ dataurl: 'data:image/png;base64,iVBORw0KGgo=' });
+
+      expect(container.querySelector('img')!.getAttribute('src')).toBe(
+        'data:image/png;base64,iVBORw0KGgo=',
+      );
+    });
+
+    it('does NOT block https: URLs in href', () => {
+      container.innerHTML = '<a href="[[url]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'https://example.com' });
+
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('https://example.com');
+    });
+
+    it('does NOT affect non-URL attributes (data-value)', () => {
+      container.innerHTML = '<div data-value="[[val]]" class="cv-bind"></div>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      // javascript: in a non-href/src attribute is passed through (not a URL context)
+      PlaceholderBinder.updateAll({ val: 'javascript:alert(1)' });
+
+      expect(container.querySelector('div')!.getAttribute('data-value')).toBe(
+        'javascript:alert(1)',
+      );
+    });
+
+    it('blocks javascript: in the conditional [[name ? t : f]] if-set path for href', () => {
+      container.innerHTML = '<a href="[[url ? $ : #]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ url: 'javascript:alert(1)' });
+
+      // The if-set template is "[[url ? $ : #]]" — when url is set, $ is substituted.
+      // isDangerousProtocol fires on the resolved val before substitution, returns ''
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+    });
+  });
+
+  describe('Security — dangerous protocol blocking does not affect template text', () => {
+    it('does not strip javascript: from plain text nodes (no cv-bind)', () => {
+      container.innerHTML = '<p>Click [[label]]</p>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      // Text nodes use {value} not href/src — no protocol filtering applied
+      // Placeholder component renders the text, not setAttribute; this just checks scan works
+      const el = container.querySelector('cv-placeholder') as HTMLElement;
+      expect(el).not.toBeNull();
+      expect(el.getAttribute('name')).toBe('label');
+    });
+  });
+
+  describe('Security — event handler attribute blocking (on*)', () => {
+    it('does NOT register onclick as an attribute template', () => {
+      container.innerHTML = '<button onclick="[[payload]]" class="cv-bind">Click</button>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      const btn = container.querySelector('button')!;
+      // Template should not have been stored for onclick
+      expect(btn.dataset.cvAttrTemplates).toBeUndefined();
+    });
+
+    it('does NOT update onclick even after updateAll', () => {
+      container.innerHTML = '<button onclick="[[payload]]" class="cv-bind">Click</button>';
+      PlaceholderBinder.scanAndHydrate(container);
+      PlaceholderBinder.updateAll({ payload: 'alert(1)' });
+
+      const btn = container.querySelector('button')!;
+      // The original attribute value must remain unchanged (not replaced with the payload)
+      expect(btn.getAttribute('onclick')).toBe('[[payload]]');
+    });
+
+    it('blocks onerror on an img', () => {
+      container.innerHTML = '<img src="x.png" onerror="[[payload]]" class="cv-bind">';
+      PlaceholderBinder.scanAndHydrate(container);
+      PlaceholderBinder.updateAll({ payload: 'alert(1)' });
+
+      expect(container.querySelector('img')!.getAttribute('onerror')).toBe('[[payload]]');
+    });
+
+    it('blocks onmouseover (case-insensitive ONMOUSEOVER)', () => {
+      container.innerHTML = '<span ONMOUSEOVER="[[payload]]" class="cv-bind">Hover</span>';
+      PlaceholderBinder.scanAndHydrate(container);
+      PlaceholderBinder.updateAll({ payload: 'alert(1)' });
+
+      const span = container.querySelector('span')!;
+      // HTML parser lowercases attribute names
+      expect(span.getAttribute('onmouseover')).toBe('[[payload]]');
+    });
+
+    it('emits a console.warn when an on* attribute contains a placeholder', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      container.innerHTML = '<button onclick="[[payload]]" class="cv-bind">Click</button>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('onclick'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('blocked for security'));
+    });
+
+    it('does NOT warn when an on* attribute has no placeholder (plain handler)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      container.innerHTML = '<button onclick="doSomething()" class="cv-bind">Click</button>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('still binds safe non-on* attributes on the same element', () => {
+      container.innerHTML =
+        '<a href="https://github.com/[[username]]" onclick="[[payload]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+      PlaceholderBinder.updateAll({ username: 'alice', payload: 'alert(1)' });
+
+      const a = container.querySelector('a')!;
+      // href is updated, onclick is left alone
+      expect(a.getAttribute('href')).toBe('https://github.com/alice');
+      expect(a.getAttribute('onclick')).toBe('[[payload]]');
+    });
+  });
+});

--- a/tests/lib/features/placeholder/placeholder-security.test.ts
+++ b/tests/lib/features/placeholder/placeholder-security.test.ts
@@ -127,6 +127,16 @@ describe('PlaceholderBinder - Security', () => {
       // isDangerousProtocol fires on the resolved val before substitution, returns ''
       expect(container.querySelector('a')!.getAttribute('href')).toBe('');
     });
+
+    it('blocks dangerous protocol assembled partially from template prefix and placeholder value (e.g. java[[scheme]])', () => {
+      container.innerHTML = '<a href="java[[scheme]]" class="cv-bind">Link</a>';
+      PlaceholderBinder.scanAndHydrate(container);
+
+      PlaceholderBinder.updateAll({ scheme: 'script:alert(1)' });
+
+      // Fully assembled value is "javascript:alert(1)" which should be blocked and set to empty string
+      expect(container.querySelector('a')!.getAttribute('href')).toBe('');
+    });
   });
 
   describe('Security — dangerous protocol blocking does not affect template text', () => {

--- a/tests/lib/features/tabs/sanitize-tab-header.test.ts
+++ b/tests/lib/features/tabs/sanitize-tab-header.test.ts
@@ -7,38 +7,7 @@
  * Any changes to the source function must be mirrored here.
  */
 import { describe, it, expect } from 'vitest';
-
-// ---------------------------------------------------------------------------
-// Inline re-implementation of sanitizeTabHeader (mirrors TabGroup.svelte)
-// Must be kept in sync with the source if the logic changes.
-// ---------------------------------------------------------------------------
-function sanitizeTabHeader(rawHtml: string): string {
-  const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
-
-  // Remove entirely unsafe elements
-  doc
-    .querySelectorAll('script, style, link, object, embed, iframe, form')
-    .forEach((el) => el.remove());
-
-  // Walk all remaining elements and strip dangerous attributes
-  doc.body.querySelectorAll('*').forEach((el) => {
-    for (const attr of Array.from(el.attributes)) {
-      // Strip all on* event handler attributes
-      if (/^on/i.test(attr.name)) {
-        el.removeAttribute(attr.name);
-        continue;
-      }
-      // Strip javascript: / vbscript: / data: from href and src
-      if (attr.name === 'href' || attr.name === 'src' || attr.name === 'action') {
-        if (/^\s*(javascript|vbscript|data):/i.test(attr.value)) {
-          el.removeAttribute(attr.name);
-        }
-      }
-    }
-  });
-
-  return doc.body.innerHTML;
-}
+import { sanitizeTabHeader } from '../../../../src/lib/utils/url-utils';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -210,6 +179,19 @@ describe('sanitizeTabHeader()', () => {
       );
       // form itself is removed; this just double-checks action is gone too
       expect(result).not.toContain('javascript:');
+    });
+
+    it('strips javascript: href containing embedded control characters or whitespace', () => {
+      // Browsers normalize/ignore tabs and newlines inside the scheme.
+      // So "java\tscript:" and "java\nscript:" resolve to "javascript:"
+      const tabResult = sanitizeTabHeader('<a href="java\tscript:alert(1)">XSS</a>');
+      expect(tabResult).not.toContain('href=');
+
+      const newlineResult = sanitizeTabHeader('<a href="java\nscript:alert(1)">XSS</a>');
+      expect(newlineResult).not.toContain('href=');
+
+      const ctrlCharResult = sanitizeTabHeader('<a href="java\x01script:alert(1)">XSS</a>');
+      expect(ctrlCharResult).not.toContain('href=');
     });
 
     it('preserves safe https: href', () => {

--- a/tests/lib/features/tabs/sanitize-tab-header.test.ts
+++ b/tests/lib/features/tabs/sanitize-tab-header.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+/**
+ * Security tests for the sanitizeTabHeader() logic used in TabGroup.svelte.
+ *
+ * sanitizeTabHeader() is defined as a local Svelte function, so we re-implement
+ * it here as a pure helper to keep tests free of Svelte component wiring.
+ * Any changes to the source function must be mirrored here.
+ */
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Inline re-implementation of sanitizeTabHeader (mirrors TabGroup.svelte)
+// Must be kept in sync with the source if the logic changes.
+// ---------------------------------------------------------------------------
+function sanitizeTabHeader(rawHtml: string): string {
+  const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
+
+  // Remove entirely unsafe elements
+  doc
+    .querySelectorAll('script, style, link, object, embed, iframe, form')
+    .forEach((el) => el.remove());
+
+  // Walk all remaining elements and strip dangerous attributes
+  doc.body.querySelectorAll('*').forEach((el) => {
+    for (const attr of Array.from(el.attributes)) {
+      // Strip all on* event handler attributes
+      if (/^on/i.test(attr.name)) {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+      // Strip javascript: / vbscript: / data: from href and src
+      if (attr.name === 'href' || attr.name === 'src' || attr.name === 'action') {
+        if (/^\s*(javascript|vbscript|data):/i.test(attr.value)) {
+          el.removeAttribute(attr.name);
+        }
+      }
+    }
+  });
+
+  return doc.body.innerHTML;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sanitizeTabHeader()', () => {
+  // -------------------------------------------------------------------------
+  // Safe rich-text — should pass through untouched
+  // -------------------------------------------------------------------------
+
+  describe('safe rich-text pass-through', () => {
+    it('passes through plain text', () => {
+      expect(sanitizeTabHeader('Overview')).toBe('Overview');
+    });
+
+    it('passes through Font Awesome icon markup', () => {
+      const html = '<i class="fa fa-home"></i> Home';
+      expect(sanitizeTabHeader(html)).toBe(html);
+    });
+
+    it('passes through <strong> and <em>', () => {
+      const html = '<strong>Bold</strong> and <em>italic</em>';
+      expect(sanitizeTabHeader(html)).toBe(html);
+    });
+
+    it('passes through <span> with a style attribute', () => {
+      const html = '<span style="color: red;">New</span>';
+      expect(sanitizeTabHeader(html)).toBe(html);
+    });
+
+    it('passes through <a> with a safe https: href', () => {
+      const html = '<a href="https://example.com">Link</a>';
+      expect(sanitizeTabHeader(html)).toBe(html);
+    });
+
+    it('passes through multiple nested safe elements', () => {
+      const html = '<span><i class="fa fa-star"></i> <strong>Featured</strong></span>';
+      expect(sanitizeTabHeader(html)).toBe(html);
+    });
+
+    it('passes through empty string', () => {
+      expect(sanitizeTabHeader('')).toBe('');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dangerous element removal
+  // -------------------------------------------------------------------------
+
+  describe('dangerous element removal', () => {
+    it('removes <script> tags', () => {
+      const result = sanitizeTabHeader('<script>alert(1)</script>Tab');
+      expect(result).not.toContain('<script>');
+      expect(result).not.toContain('alert(1)');
+      expect(result).toContain('Tab');
+    });
+
+    it('removes <style> tags', () => {
+      const result = sanitizeTabHeader('<style>body{display:none}</style>Tab');
+      expect(result).not.toContain('<style>');
+      expect(result).toContain('Tab');
+    });
+
+    it('removes <iframe> tags', () => {
+      const result = sanitizeTabHeader('<iframe src="https://evil.com"></iframe>Tab');
+      expect(result).not.toContain('<iframe>');
+      expect(result).toContain('Tab');
+    });
+
+    it('removes <object> tags', () => {
+      const result = sanitizeTabHeader('<object data="evil.swf"></object>Tab');
+      expect(result).not.toContain('<object>');
+      expect(result).toContain('Tab');
+    });
+
+    it('removes <embed> tags', () => {
+      const result = sanitizeTabHeader('<embed src="evil.swf">Tab');
+      expect(result).not.toContain('<embed>');
+      expect(result).toContain('Tab');
+    });
+
+    it('removes <form> tags', () => {
+      const result = sanitizeTabHeader('<form action="//evil.com"><input></form>Tab');
+      expect(result).not.toContain('<form>');
+      expect(result).toContain('Tab');
+    });
+
+    it('removes <link> tags', () => {
+      const result = sanitizeTabHeader('<link rel="stylesheet" href="evil.css">Tab');
+      expect(result).not.toContain('<link>');
+      expect(result).toContain('Tab');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dangerous attribute stripping
+  // -------------------------------------------------------------------------
+
+  describe('event handler attribute stripping', () => {
+    it('strips onclick attribute', () => {
+      const result = sanitizeTabHeader('<span onclick="alert(1)">Click</span>');
+      expect(result).not.toContain('onclick');
+      expect(result).toContain('Click');
+    });
+
+    it('strips onmouseover attribute', () => {
+      const result = sanitizeTabHeader('<img src="x.png" onmouseover="alert(1)">');
+      expect(result).not.toContain('onmouseover');
+    });
+
+    it('strips onerror attribute', () => {
+      const result = sanitizeTabHeader('<img src="x" onerror="alert(1)">');
+      expect(result).not.toContain('onerror');
+    });
+
+    it('strips on* attributes case-insensitively (ONCLICK)', () => {
+      const result = sanitizeTabHeader('<span ONCLICK="alert(1)">x</span>');
+      // HTML parser normalises to lowercase, check both
+      expect(result.toLowerCase()).not.toContain('onclick');
+    });
+
+    it('strips multiple event handlers on the same element', () => {
+      const result = sanitizeTabHeader(
+        '<a href="https://ok.com" onclick="bad()" onmouseout="also_bad()">Safe</a>',
+      );
+      expect(result).not.toContain('onclick');
+      expect(result).not.toContain('onmouseout');
+      expect(result).toContain('href="https://ok.com"');
+      expect(result).toContain('Safe');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dangerous protocol stripping in href / src / action
+  // -------------------------------------------------------------------------
+
+  describe('dangerous protocol stripping in href/src/action', () => {
+    it('strips javascript: href', () => {
+      const result = sanitizeTabHeader('<a href="javascript:alert(1)">XSS</a>');
+      expect(result).not.toContain('javascript:');
+      expect(result).toContain('XSS');
+    });
+
+    it('strips javascript: href (uppercase)', () => {
+      const result = sanitizeTabHeader('<a href="JAVASCRIPT:alert(1)">XSS</a>');
+      expect(result).not.toContain('JAVASCRIPT:');
+      expect(result).toContain('XSS');
+    });
+
+    it('strips javascript: href with leading whitespace', () => {
+      const result = sanitizeTabHeader('<a href="  javascript:alert(1)">XSS</a>');
+      expect(result).not.toContain('javascript:');
+    });
+
+    it('strips vbscript: href', () => {
+      const result = sanitizeTabHeader('<a href="vbscript:MsgBox(1)">XSS</a>');
+      expect(result).not.toContain('vbscript:');
+    });
+
+    it('strips data: src', () => {
+      // data: in src is blocked (unlike in placeholder-binder where data:image is allowed)
+      const result = sanitizeTabHeader('<img src="data:text/html,<script>alert(1)</script>">');
+      expect(result).not.toContain('data:');
+    });
+
+    it('strips javascript: in action attribute', () => {
+      const result = sanitizeTabHeader(
+        '<form action="javascript:submit()"><button>Go</button></form>',
+      );
+      // form itself is removed; this just double-checks action is gone too
+      expect(result).not.toContain('javascript:');
+    });
+
+    it('preserves safe https: href', () => {
+      const result = sanitizeTabHeader('<a href="https://example.com">Safe</a>');
+      expect(result).toContain('href="https://example.com"');
+    });
+
+    it('preserves safe relative href', () => {
+      const result = sanitizeTabHeader('<a href="/page/section">Safe</a>');
+      expect(result).toContain('href="/page/section"');
+    });
+  });
+});

--- a/tests/lib/features/tabs/sanitize-tab-header.test.ts
+++ b/tests/lib/features/tabs/sanitize-tab-header.test.ts
@@ -1,10 +1,6 @@
 // @vitest-environment jsdom
 /**
- * Security tests for the sanitizeTabHeader() logic used in TabGroup.svelte.
- *
- * sanitizeTabHeader() is defined as a local Svelte function, so we re-implement
- * it here as a pure helper to keep tests free of Svelte component wiring.
- * Any changes to the source function must be mirrored here.
+ * Security tests for the shared sanitizeTabHeader() helper.
  */
 import { describe, it, expect } from 'vitest';
 import { sanitizeTabHeader } from '../../../../src/lib/utils/url-utils';
@@ -192,6 +188,19 @@ describe('sanitizeTabHeader()', () => {
 
       const ctrlCharResult = sanitizeTabHeader('<a href="java\x01script:alert(1)">XSS</a>');
       expect(ctrlCharResult).not.toContain('href=');
+    });
+
+    it('strips javascript: from namespaced SVG xlink:href attributes', () => {
+      const result = sanitizeTabHeader('<svg><use xlink:href="javascript:alert(1)"></use></svg>');
+      // xlink:href should be stripped
+      expect(result).not.toContain('xlink:href=');
+      expect(result).not.toContain('javascript:');
+    });
+
+    it('strips javascript: from formaction attribute', () => {
+      const result = sanitizeTabHeader('<button formaction="javascript:alert(1)">Go</button>');
+      expect(result).not.toContain('formaction=');
+      expect(result).not.toContain('javascript:');
     });
 
     it('preserves safe https: href', () => {

--- a/tests/lib/utils/scroll-utils.test.ts
+++ b/tests/lib/utils/scroll-utils.test.ts
@@ -164,7 +164,9 @@ describe('scroll-utils', () => {
     it('respects header offset (ignores elements above current viewport top)', () => {
       const header = document.createElement('header');
       document.body.appendChild(header);
-      vi.spyOn(window, 'getComputedStyle').mockReturnValue({ position: 'fixed' } as unknown as CSSStyleDeclaration);
+      vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+        position: 'fixed',
+      } as unknown as CSSStyleDeclaration);
       vi.spyOn(header, 'getBoundingClientRect').mockReturnValue({ height: 100 } as DOMRect);
 
       // el1 is partially under the header (bottom is 100, offset is 100)
@@ -185,7 +187,9 @@ describe('scroll-utils', () => {
     it('ignores elements that are inside the sticky/fixed header', () => {
       const header = document.createElement('header');
       document.body.appendChild(header);
-      vi.spyOn(window, 'getComputedStyle').mockReturnValue({ position: 'fixed' } as unknown as CSSStyleDeclaration);
+      vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+        position: 'fixed',
+      } as unknown as CSSStyleDeclaration);
       vi.spyOn(header, 'getBoundingClientRect').mockReturnValue({ height: 100 } as DOMRect);
 
       const elInHeader = document.createElement('div');


### PR DESCRIPTION
**Overview of changes:**

Addresses #255

Adds some security Enhancements:
- **XSS Prevention in Tab Headers**: Added native `DOMParser` sanitization to safely permit rich text tags (`<i>`, `<span>`, etc.) while stripping scripts, specific suspicious tags, and event handlers.
- **Protocol Guarding**: Blocked `javascript:`, `vbscript:`, URIs in dynamically bound placeholder links (`href`/`src`).
- **CSS Injection Protection**: Add validation on custom CSS variable inputs to prevent malformed attributes, `url()`, script payloads.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:

- [ ] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
