### PR TITLE
Add CustardUI version into settings modal footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/js": "^9.39.2",
         "@rollup/plugin-alias": "^6.0.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.4",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -1026,6 +1027,28 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@eslint/js": "^9.39.2",
     "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
+    "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.4",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import svelte from 'rollup-plugin-svelte';
 import svelteConfig from './svelte.config.js';
 
 import alias from '@rollup/plugin-alias';
+import replace from '@rollup/plugin-replace';
 import path from 'path';
 
 import resolve from '@rollup/plugin-node-resolve';
@@ -57,6 +58,10 @@ const sveltePluginRegular = svelte({
 
 // Plugin tools pipeline, build is for browser, dedupe prevents bundling Svelte multiple times
 const plugins = [
+  replace({
+    preventAssignment: true,
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  }),
   alias({
     entries: [
       { find: '$lib', replacement: path.resolve('src/lib') },

--- a/src/lib/features/settings/Modal.svelte
+++ b/src/lib/features/settings/Modal.svelte
@@ -357,14 +357,17 @@
 
       <div class="footer-attribution">
         <span class="footer-tagline">Browser-side page customisations provided by</span>
-        <a
-          href="https://custardui.js.org"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="footer-link"
-        >
-          custardui.js.org
-        </a>
+        <div class="footer-link-container">
+          <a
+            href="https://custardui.js.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="footer-link"
+          >
+            custardui.js.org
+          </a>
+          <span class="footer-version">v{__APP_VERSION__}</span>
+        </div>
       </div>
 
       <button type="button" class="done-btn" onclick={onclose}>Done</button>
@@ -696,6 +699,19 @@
 
   .footer-link:hover {
     color: var(--cv-primary);
+  }
+
+  .footer-link-container {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .footer-version {
+    font-size: 0.65rem;
+    color: var(--cv-text);
+    opacity: 0.9;
+    letter-spacing: 0.04em;
   }
 
   .reset-btn {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [
     tsconfigPaths({ projects: ['./tsconfig.test.json'] }),
     svelte({ hot: !process.env.VITEST }),


### PR DESCRIPTION
**Overview of changes:**

<!-- Add link to issue, or summary of changes.-->

Closes #231

Add version to modal footer.

<img width="501" height="56" alt="image" src="https://github.com/user-attachments/assets/38b95f4a-7a1d-4507-b71f-7d3652a5d09d" />

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [x] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:

- [x] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
