### PR TITLE
Add icons to labels

### DIFF
--- a/docs/authorGuide/components/labels.md
+++ b/docs/authorGuide/components/labels.md
@@ -129,7 +129,42 @@ Text color (black or white) is auto-computed for contrast against the resolved b
 </variable>
 </include>
 
----
+<br>
+
+### Rich Formatting and Icons
+
+Labels support rich HTML formatting, meaning you can easily include icons or styled text. Global stylesheets (such as Font Awesome) are automatically injected, allowing icon classes to render perfectly.
+
+#### Using Icons via Slot
+
+When you write content directly inside the `<cv-label>` tag, you can include icons in two ways:
+1. **Via MarkBind shortcodes** (when using MarkBind) — MarkBind pre-processes `:fa-solid-icon:` into `<i>` elements. For them to render, you must wrap the slot content with `<md>`. 
+2. **Via direct HTML** — Include Font Awesome `<i>` tags directly.
+
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
+<cv-label name="new" color="g"><md>:fa-solid-star: NEW</md></cv-label>
+<cv-label name="warning" color="y"><strong>⚠ IMPORTANT</strong></cv-label>
+<cv-label name="pro" color="m"><i class="fa-solid fa-crown"></i>  &nbsp; PRO</cv-label>
+</variable>
+</include>
+
+#### Using Icons via Config
+
+If you specify a `value` in `custardui.config.json` or through an adaptation override, it also fully supports HTML. This allows different adaptations to use different icons.
+
+```json
+{
+  "name": "pro",
+  "value": "<i class=\"fa-solid fa-crown\"></i> PRO",
+  "color": "m"
+}
+```
+
+*Note: You must use direct HTML like `<i class="..."></i>` in configuration files, as MarkBind shortcodes are not processed inside JSON.*
+
+
 <br>
 
 ### Adaptation Overrides

--- a/src/lib/features/labels/components/Label.svelte
+++ b/src/lib/features/labels/components/Label.svelte
@@ -12,6 +12,7 @@
   import { labelRegistryStore } from '../label-registry-store.svelte';
   import { colorSchemeStore } from '$lib/stores/color-scheme-store.svelte';
   import { computeTextColor, resolveColor } from '../label-utils';
+  import { sanitizeHtml } from '$lib/utils/url-utils';
 
   let { name = '', color = '' }: { name?: string; color?: string } = $props();
 
@@ -42,9 +43,16 @@
 </script>
 
 {#if labelDef?.value || hasSlotContent}
+  {#if labelDef?.value}
+    <!-- Inject global stylesheets to support icons (FontAwesome, etc.) inside Shadow DOM -->
+    {#each Array.from(document.querySelectorAll('link[rel="stylesheet"]')) as link ((link as HTMLLinkElement).href)}
+      <link rel="stylesheet" href={(link as HTMLLinkElement).href} />
+    {/each}
+  {/if}
   <span class="cv-label" style:background={bgColor} style:color={textColor}>
     {#if labelDef?.value}
-      {labelDef.value}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html sanitizeHtml(labelDef.value)}
     {:else}
       <slot></slot>
     {/if}

--- a/src/lib/features/tabs/components/TabGroup.svelte
+++ b/src/lib/features/tabs/components/TabGroup.svelte
@@ -15,7 +15,7 @@
   import { elementStore } from '$lib/stores/element-store.svelte';
   import { uiStore } from '$lib/stores/ui-store.svelte';
   import { captureScrollAnchor, restoreScrollAnchor } from '$lib/utils/scroll-utils';
-  import { sanitizeTabHeader } from '$lib/utils/url-utils';
+  import { sanitizeHtml } from '$lib/utils/url-utils';
 
   //  ID of the tabgroup Group
   let { groupId, stabilizeScroll = true } = $props<{
@@ -139,7 +139,7 @@
       // Check for <cv-tab-header>
       const headerEl = element.querySelector('cv-tab-header');
       if (headerEl) {
-        header = sanitizeTabHeader(headerEl.innerHTML.trim());
+        header = sanitizeHtml(headerEl.innerHTML.trim());
       } else {
         // Attribute syntax — also supports raw HTML (e.g. <i> icons), so sanitize too
         const rawAttrHeader =
@@ -148,7 +148,7 @@
           '';
 
         if (rawAttrHeader) {
-          header = sanitizeTabHeader(rawAttrHeader);
+          header = sanitizeHtml(rawAttrHeader);
         } else {
           // Fallback to tab-id or default
           header = element.getAttribute('tab-id') ? primaryId : `Tab ${index + 1}`;

--- a/src/lib/utils/url-utils.ts
+++ b/src/lib/utils/url-utils.ts
@@ -34,12 +34,12 @@ export function hasDangerousProtocol(
 }
 
 /**
- * Sanitizes HTML sourced from cv-tab-header innerHTML or header attribute.
+ * Sanitizes HTML sourced from user input (e.g. cv-tab-header innerHTML, label values).
  * Strips script, style, link, and all inline event handler attributes (on*)
  * and javascript:/vbscript:/data: URLs from href/src/action, preserving safe rich formatting.
  * Uses DOMParser — no external dependencies.
  */
-export function sanitizeTabHeader(rawHtml: string): string {
+export function sanitizeHtml(rawHtml: string): string {
   if (typeof DOMParser === 'undefined') {
     // Return rawHtml if DOMParser is not available (e.g., SSR or node context without jsdom),
     // though in our actual runtime it's browser-only.

--- a/tests/lib/features/tabs/sanitize-tab-header.test.ts
+++ b/tests/lib/features/tabs/sanitize-tab-header.test.ts
@@ -1,51 +1,51 @@
 // @vitest-environment jsdom
 /**
- * Security tests for the shared sanitizeTabHeader() helper.
+ * Security tests for the shared sanitizeHtml() helper.
  */
 import { describe, it, expect } from 'vitest';
-import { sanitizeTabHeader } from '../../../../src/lib/utils/url-utils';
+import { sanitizeHtml } from '../../../../src/lib/utils/url-utils';
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('sanitizeTabHeader()', () => {
+describe('sanitizeHtml()', () => {
   // -------------------------------------------------------------------------
   // Safe rich-text — should pass through untouched
   // -------------------------------------------------------------------------
 
   describe('safe rich-text pass-through', () => {
     it('passes through plain text', () => {
-      expect(sanitizeTabHeader('Overview')).toBe('Overview');
+      expect(sanitizeHtml('Overview')).toBe('Overview');
     });
 
     it('passes through Font Awesome icon markup', () => {
       const html = '<i class="fa fa-home"></i> Home';
-      expect(sanitizeTabHeader(html)).toBe(html);
+      expect(sanitizeHtml(html)).toBe(html);
     });
 
     it('passes through <strong> and <em>', () => {
       const html = '<strong>Bold</strong> and <em>italic</em>';
-      expect(sanitizeTabHeader(html)).toBe(html);
+      expect(sanitizeHtml(html)).toBe(html);
     });
 
     it('passes through <span> with a style attribute', () => {
       const html = '<span style="color: red;">New</span>';
-      expect(sanitizeTabHeader(html)).toBe(html);
+      expect(sanitizeHtml(html)).toBe(html);
     });
 
     it('passes through <a> with a safe https: href', () => {
       const html = '<a href="https://example.com">Link</a>';
-      expect(sanitizeTabHeader(html)).toBe(html);
+      expect(sanitizeHtml(html)).toBe(html);
     });
 
     it('passes through multiple nested safe elements', () => {
       const html = '<span><i class="fa fa-star"></i> <strong>Featured</strong></span>';
-      expect(sanitizeTabHeader(html)).toBe(html);
+      expect(sanitizeHtml(html)).toBe(html);
     });
 
     it('passes through empty string', () => {
-      expect(sanitizeTabHeader('')).toBe('');
+      expect(sanitizeHtml('')).toBe('');
     });
   });
 
@@ -55,44 +55,44 @@ describe('sanitizeTabHeader()', () => {
 
   describe('dangerous element removal', () => {
     it('removes <script> tags', () => {
-      const result = sanitizeTabHeader('<script>alert(1)</script>Tab');
+      const result = sanitizeHtml('<script>alert(1)</script>Tab');
       expect(result).not.toContain('<script>');
       expect(result).not.toContain('alert(1)');
       expect(result).toContain('Tab');
     });
 
     it('removes <style> tags', () => {
-      const result = sanitizeTabHeader('<style>body{display:none}</style>Tab');
+      const result = sanitizeHtml('<style>body{display:none}</style>Tab');
       expect(result).not.toContain('<style>');
       expect(result).toContain('Tab');
     });
 
     it('removes <iframe> tags', () => {
-      const result = sanitizeTabHeader('<iframe src="https://evil.com"></iframe>Tab');
+      const result = sanitizeHtml('<iframe src="https://evil.com"></iframe>Tab');
       expect(result).not.toContain('<iframe>');
       expect(result).toContain('Tab');
     });
 
     it('removes <object> tags', () => {
-      const result = sanitizeTabHeader('<object data="evil.swf"></object>Tab');
+      const result = sanitizeHtml('<object data="evil.swf"></object>Tab');
       expect(result).not.toContain('<object>');
       expect(result).toContain('Tab');
     });
 
     it('removes <embed> tags', () => {
-      const result = sanitizeTabHeader('<embed src="evil.swf">Tab');
+      const result = sanitizeHtml('<embed src="evil.swf">Tab');
       expect(result).not.toContain('<embed>');
       expect(result).toContain('Tab');
     });
 
     it('removes <form> tags', () => {
-      const result = sanitizeTabHeader('<form action="//evil.com"><input></form>Tab');
+      const result = sanitizeHtml('<form action="//evil.com"><input></form>Tab');
       expect(result).not.toContain('<form>');
       expect(result).toContain('Tab');
     });
 
     it('removes <link> tags', () => {
-      const result = sanitizeTabHeader('<link rel="stylesheet" href="evil.css">Tab');
+      const result = sanitizeHtml('<link rel="stylesheet" href="evil.css">Tab');
       expect(result).not.toContain('<link>');
       expect(result).toContain('Tab');
     });
@@ -104,29 +104,29 @@ describe('sanitizeTabHeader()', () => {
 
   describe('event handler attribute stripping', () => {
     it('strips onclick attribute', () => {
-      const result = sanitizeTabHeader('<span onclick="alert(1)">Click</span>');
+      const result = sanitizeHtml('<span onclick="alert(1)">Click</span>');
       expect(result).not.toContain('onclick');
       expect(result).toContain('Click');
     });
 
     it('strips onmouseover attribute', () => {
-      const result = sanitizeTabHeader('<img src="x.png" onmouseover="alert(1)">');
+      const result = sanitizeHtml('<img src="x.png" onmouseover="alert(1)">');
       expect(result).not.toContain('onmouseover');
     });
 
     it('strips onerror attribute', () => {
-      const result = sanitizeTabHeader('<img src="x" onerror="alert(1)">');
+      const result = sanitizeHtml('<img src="x" onerror="alert(1)">');
       expect(result).not.toContain('onerror');
     });
 
     it('strips on* attributes case-insensitively (ONCLICK)', () => {
-      const result = sanitizeTabHeader('<span ONCLICK="alert(1)">x</span>');
+      const result = sanitizeHtml('<span ONCLICK="alert(1)">x</span>');
       // HTML parser normalises to lowercase, check both
       expect(result.toLowerCase()).not.toContain('onclick');
     });
 
     it('strips multiple event handlers on the same element', () => {
-      const result = sanitizeTabHeader(
+      const result = sanitizeHtml(
         '<a href="https://ok.com" onclick="bad()" onmouseout="also_bad()">Safe</a>',
       );
       expect(result).not.toContain('onclick');
@@ -142,35 +142,35 @@ describe('sanitizeTabHeader()', () => {
 
   describe('dangerous protocol stripping in href/src/action', () => {
     it('strips javascript: href', () => {
-      const result = sanitizeTabHeader('<a href="javascript:alert(1)">XSS</a>');
+      const result = sanitizeHtml('<a href="javascript:alert(1)">XSS</a>');
       expect(result).not.toContain('javascript:');
       expect(result).toContain('XSS');
     });
 
     it('strips javascript: href (uppercase)', () => {
-      const result = sanitizeTabHeader('<a href="JAVASCRIPT:alert(1)">XSS</a>');
+      const result = sanitizeHtml('<a href="JAVASCRIPT:alert(1)">XSS</a>');
       expect(result).not.toContain('JAVASCRIPT:');
       expect(result).toContain('XSS');
     });
 
     it('strips javascript: href with leading whitespace', () => {
-      const result = sanitizeTabHeader('<a href="  javascript:alert(1)">XSS</a>');
+      const result = sanitizeHtml('<a href="  javascript:alert(1)">XSS</a>');
       expect(result).not.toContain('javascript:');
     });
 
     it('strips vbscript: href', () => {
-      const result = sanitizeTabHeader('<a href="vbscript:MsgBox(1)">XSS</a>');
+      const result = sanitizeHtml('<a href="vbscript:MsgBox(1)">XSS</a>');
       expect(result).not.toContain('vbscript:');
     });
 
     it('strips data: src', () => {
       // data: in src is blocked (unlike in placeholder-binder where data:image is allowed)
-      const result = sanitizeTabHeader('<img src="data:text/html,<script>alert(1)</script>">');
+      const result = sanitizeHtml('<img src="data:text/html,<script>alert(1)</script>">');
       expect(result).not.toContain('data:');
     });
 
     it('strips javascript: in action attribute', () => {
-      const result = sanitizeTabHeader(
+      const result = sanitizeHtml(
         '<form action="javascript:submit()"><button>Go</button></form>',
       );
       // form itself is removed; this just double-checks action is gone too
@@ -180,36 +180,36 @@ describe('sanitizeTabHeader()', () => {
     it('strips javascript: href containing embedded control characters or whitespace', () => {
       // Browsers normalize/ignore tabs and newlines inside the scheme.
       // So "java\tscript:" and "java\nscript:" resolve to "javascript:"
-      const tabResult = sanitizeTabHeader('<a href="java\tscript:alert(1)">XSS</a>');
+      const tabResult = sanitizeHtml('<a href="java\tscript:alert(1)">XSS</a>');
       expect(tabResult).not.toContain('href=');
 
-      const newlineResult = sanitizeTabHeader('<a href="java\nscript:alert(1)">XSS</a>');
+      const newlineResult = sanitizeHtml('<a href="java\nscript:alert(1)">XSS</a>');
       expect(newlineResult).not.toContain('href=');
 
-      const ctrlCharResult = sanitizeTabHeader('<a href="java\x01script:alert(1)">XSS</a>');
+      const ctrlCharResult = sanitizeHtml('<a href="java\x01script:alert(1)">XSS</a>');
       expect(ctrlCharResult).not.toContain('href=');
     });
 
     it('strips javascript: from namespaced SVG xlink:href attributes', () => {
-      const result = sanitizeTabHeader('<svg><use xlink:href="javascript:alert(1)"></use></svg>');
+      const result = sanitizeHtml('<svg><use xlink:href="javascript:alert(1)"></use></svg>');
       // xlink:href should be stripped
       expect(result).not.toContain('xlink:href=');
       expect(result).not.toContain('javascript:');
     });
 
     it('strips javascript: from formaction attribute', () => {
-      const result = sanitizeTabHeader('<button formaction="javascript:alert(1)">Go</button>');
+      const result = sanitizeHtml('<button formaction="javascript:alert(1)">Go</button>');
       expect(result).not.toContain('formaction=');
       expect(result).not.toContain('javascript:');
     });
 
     it('preserves safe https: href', () => {
-      const result = sanitizeTabHeader('<a href="https://example.com">Safe</a>');
+      const result = sanitizeHtml('<a href="https://example.com">Safe</a>');
       expect(result).toContain('href="https://example.com"');
     });
 
     it('preserves safe relative href', () => {
-      const result = sanitizeTabHeader('<a href="/page/section">Safe</a>');
+      const result = sanitizeHtml('<a href="/page/section">Safe</a>');
       expect(result).toContain('href="/page/section"');
     });
   });


### PR DESCRIPTION
**Overview of changes:**

<!-- Add link to issue, or summary of changes.-->

Targets #263 somewhat by adding icon support for labels, but it is still not exactly the solution as it does not allow shorthand icons (which is a markbind feature) to be used in the values of the label configs. 

Rather, it enables HTML usage for the values, so something like `<i class=\"fa-solid fa-crown\"></i>` will be recognized as an icon and be able to render as an icon for the labels.

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [x] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:

- [x] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
