### PR TITLE
Add <cv-insertion> element for inserting HTML for adaptations

### DIFF
--- a/docs/_markbind/layouts/authorGuide.md
+++ b/docs/_markbind/layouts/authorGuide.md
@@ -21,11 +21,12 @@
   * [Share Modes]({{baseUrl}}/authorGuide/focusedViews/shareModes.html)
   * [Show and Hide]({{baseUrl}}/authorGuide/focusedViews/showHideModes.html)
   * [Highlighting Pages]({{baseUrl}}/authorGuide/focusedViews/highlightModes.html)
-* [URL Sharing]({{baseUrl}}/authorGuide/urlSharing.html)
-* Site Adaptations
+* Site Adaptations :expanded:
   * [Adaptations]({{baseUrl}}/authorGuide/adaptations/adaptations.html)
+  * [Insertions]({{baseUrl}}/authorGuide/adaptations/insertions.html)
   * [Configuration]({{baseUrl}}/authorGuide/adaptations/configuration.html)
   * [Sample Adaptation Page]({{baseUrl}}/authorGuide/adaptations/samplePage.html)
+* [URL Sharing]({{baseUrl}}/authorGuide/urlSharing.html)
       </site-nav>
     </div>
   </nav>

--- a/docs/_markbind/plugins/custardui-betadocs.js
+++ b/docs/_markbind/plugins/custardui-betadocs.js
@@ -22,7 +22,8 @@ const tagConfig = {
 	'cv-tab-header': { isCustomElement: true },
 	'cv-define-placeholder': { isCustomElement: true },
 	'cv-placeholder-input': { isCustomElement: true },
-	'cv-label': { isCustomElement: true }
+	'cv-label': { isCustomElement: true },
+	'cv-insertion': { isCustomElement: true }
 };
 
 // CJS: module.exports = { getScripts };

--- a/docs/_markbind/plugins/custardui-devdocs.js
+++ b/docs/_markbind/plugins/custardui-devdocs.js
@@ -22,7 +22,8 @@ const tagConfig = {
 	'cv-tab-header': { isCustomElement: true },
 	'cv-define-placeholder': { isCustomElement: true },
 	'cv-placeholder-input': { isCustomElement: true },
-	'cv-label': { isCustomElement: true }
+	'cv-label': { isCustomElement: true },
+	'cv-insertion': { isCustomElement: true }
 };
 
 // CJS: module.exports = { getScripts };

--- a/docs/_markbind/plugins/custardui.js
+++ b/docs/_markbind/plugins/custardui.js
@@ -22,7 +22,8 @@ const tagConfig = {
 	'cv-tab-header': { isCustomElement: true },
 	'cv-define-placeholder': { isCustomElement: true },
 	'cv-placeholder-input': { isCustomElement: true },
-	'cv-label': { isCustomElement: true }
+	'cv-label': { isCustomElement: true },
+	'cv-insertion': { isCustomElement: true }
 };
 
 // CJS: module.exports = { getScripts };

--- a/docs/authorGuide/adaptations/configuration.md
+++ b/docs/authorGuide/adaptations/configuration.md
@@ -16,6 +16,7 @@
 {
   "id": "org-a",
   "name": "Organization A",
+  "insertionsFile": "insertions.html",
   "theme": {
     "cssVariables": {
       "--cv-primary": "#003d7c",
@@ -40,7 +41,8 @@
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `id` | `string` | **Yes** | Must exactly match the filename and the `?adapt=` value. |
-| `name` | `string` | No | Human-readable name (reserved for future UI use). |
+| `name` | `string` | No | Human-readable name shown as the attribution label in `<cv-insertion>` callouts. |
+| `insertionsFile` | `string` | No | Filename of the adopter insertions file within the adaptation folder. Defaults to `insertions.html`. See [Insertions](./insertions.html). |
 | `theme` | `object` | No | CSS overrides applied immediately on activation. |
 | `preset` | `object` | No | State overrides applied before persisted user choices. |
 

--- a/docs/authorGuide/adaptations/insertions.md
+++ b/docs/authorGuide/adaptations/insertions.md
@@ -1,0 +1,211 @@
+{% set title = "Adaptation Insertions" %}
+<span id="title" class="d-none">{{ title }}</span>
+
+<frontmatter>
+  title: "Author Guide - Adaptation Insertions"
+  layout: authorGuide.md
+  pageNav: 3
+  pageNavTitle: "Topics"
+</frontmatter>
+
+## Insertions
+
+`<cv-insertion>`
+
+**Insertions** let adopters inject their own content at specific points in site pages — without modifying the original source. They are ideal for institution-specific preambles, deadline reminders, or notes before exercises that the original site author has designated as injectable.
+
+**View as:** [NUS](./insertions.html?adapt=nus) · [Reset](./insertions.html?adapt=clear)
+
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
+<cv-insertion insertion-id="week1-preamble">
+
+*No institution-specific note for this section.*
+
+</cv-insertion>
+
+<cv-insertion insertion-id="week2-preamble">
+
+*No institution-specific note for this section.*
+
+</cv-insertion>
+</variable>
+</include>
+
+When the active adaptation has a matching block in its `insertions.html`, the `<cv-insertion>` element renders it as a styled adopter callout. When there is no matching block — or no adaptation is active — the **default slot content** (children) is shown instead.
+
+### Basic Syntax
+
+```html
+<cv-insertion insertion-id="exercise-1-preamble">
+  Default content shown when no insertion matches.
+</cv-insertion>
+```
+
+> `insertion-id` attribute is used for the lookup key for the `<cv-insertion insertion-id="...">` element, while the matching `<div id="...">` block in `insertion.html` uses `id` as the lookup key. This is because standard `id` attributes must be unique per page. This allows you to safely reuse the same insertion point multiple times without breaking HTML validation or browser anchor routing.
+
+### `insertions.html` Format
+
+Each adopter creates an `insertions.html` file in their adaptation folder. Each `<div id="...">` element defines one injection block — the `id` is the lookup key and the `innerHTML` is what gets rendered.
+
+**`insertion.html` / `insertion.md` (for static site generators like MarkBind)** 
+
+```html
+<!-- versions/org-a/insertions.html -->
+<div id="week1-preamble">
+  <p>
+    <strong>NUS CS2103T students:</strong> Before starting this section, make sure you have
+    accepted the GitHub Classroom invitation and set up your individual project repository.
+    Refer to the course schedule for this week's exact deadline.
+  </p>
+</div> 
+
+<!-- versions/org-a/insertions.md (for MarkBind or SSGs):-->
+<div id="week2-preamble" label="week 2" color="#ef4444">
+
+Complete this right after Week 1's tasks. This exercise is **examinable** —
+ensure you understand each step before proceeding.
+
+</div>
+```
+
+The `insertion-id` links the tag to a `<div id="...">` in the adopter's `insertions.html`. When a match is found, the adopter's HTML replaces the default slot content and is wrapped in a labelled callout block.
+
+<box type="info">
+
+Only `<div id="...">` elements are extracted — at any depth in the file. Other top-level elements (paragraphs, comments, etc.) are ignored.
+
+</box>
+
+<box type="tip">
+
+You can include any HTML inside the `<div>` blocks: paragraphs, lists, bold text, links, etc. The content is rendered as-is inside the adopter callout.
+
+</box>
+
+### Attributes of `<cv-insertion>`
+
+| Name           | Type     | Default      | Description |
+| -------------- | -------- | ------------ | ----------- |
+| `insertion-id` | `string` | **required** | The lookup key. Must match the `id` attribute of a `<div>` in the active adaptation's `insertions.html`. |
+| `label`        | `string` | —            | Attribution label shown in the callout header. Takes highest precedence, overriding both the `<div>` attribute and the adaptation `name` config. |
+| `color`        | `string` | —            | Custom color for the insertion callout (e.g. `#ef4444`). Takes highest precedence, overriding both the `<div>` attribute and the adaptation `--cv-primary` theme. |
+
+**Slot (default content):** Any children inside `<cv-insertion>` are rendered when no adaptation is active, or when the active adaptation has no matching `id` in its `insertions.html`.
+
+<br>
+
+### Attributes of `<div>` (in insertions.html)
+
+| Name    | Type     | Default      | Description |
+| ------- | -------- | ------------ | ----------- |
+| `id`    | `string` | **required** | The lookup key. Must match the `insertion-id` of a `<cv-insertion>` tag. |
+| `label` | `string` | —            | Attribution label shown in the callout header. Overrides the adaptation's `name` config, but is overridden by the `<cv-insertion>` tag's `label` attribute. |
+| `color` | `string` | —            | Custom color for the callout (e.g. `#ef4444`). Overrides the adaptation's `--cv-primary` theme, but is overridden by the `<cv-insertion>` tag's `color` attribute. |
+
+
+### With Attribution Label
+
+Use the `label` attribute to override the attribution label shown in the callout header for a specific insertion point. When omitted, the label defaults to the adaptation's `name` field from its JSON config.
+
+### With Custom Color
+
+Use the `color` attribute to override the color of the callout box and its label. This is useful for color-coding specific insertions (e.g. red for deadlines, green for tips). You can provide any valid CSS color, including hex codes like `#ef4444`.
+
+```html
+<cv-insertion insertion-id="exercise-1-preamble" color="#ef4444">
+  Default content shown when no insertion matches.
+</cv-insertion>
+```
+
+When omitted, the color defaults to the active adaptation's `--cv-primary` theme color.
+
+### No Default Content
+
+If an insertion point has no meaningful default, you can use a self-closing tag. The element renders nothing when no matching block is found:
+
+```html
+<cv-insertion insertion-id="week3-note" />
+```
+
+
+## File Placement
+
+By default, CustardUI looks for `insertions.html` in the same folder as the adaptation's JSON config:
+
+```
+{baseUrl}/{adaptationsPath}/{id}/insertions.html
+```
+
+| `data-base-url` | `adaptationsPath` | Adaptation id | Fetched from |
+| --- | --- | --- | --- |
+| `/docs` | `versions` *(default)* | `org-a` | `/docs/versions/org-a/insertions.html` |
+| `/docs` | `adaptations` | `org-a` | `/docs/adaptations/org-a/insertions.html` |
+| *(empty)* | `versions` *(default)* | `org-a` | `/versions/org-a/insertions.html` |
+
+The conventional layout keeps the insertions file alongside the adaptation config:
+
+```
+versions/
+  org-a/
+    org-a.json       ← adaptation config
+    insertions.html  ← adopter insertions
+    index.md         ← optional landing page
+```
+
+### Custom Filename
+
+To use a different filename, set `insertionsFile` in the adaptation's JSON config:
+
+```json
+{
+  "id": "org-a",
+  "insertionsFile": "notes.html"
+}
+```
+
+CustardUI will then fetch `{adaptationsPath}/org-a/notes.html` instead. If the field is omitted, `insertions.html` is used.
+
+<box type="info">
+
+If the file is missing (404), CustardUI silently skips loading insertions — no error is shown and all `<cv-insertion>` tags fall back to their default slot content.
+
+</box>
+
+---
+<br>
+
+## Adaptation Config
+
+The `insertionsFile` field is optional and belongs at the top level of the adaptation JSON:
+
+```json
+{
+  "id": "nus",
+  "name": "NUS",
+  "insertionsFile": "insertions.html",
+  "preset": {
+    "toggles": { "nus-resources": "show" }
+  }
+}
+```
+
+The `name` field is used as the default attribution label in all `<cv-insertion>` callout headers for this adaptation (unless overridden per-tag via `name` attribute).
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | — | Human-readable adaptation name. Shown as the attribution label in `<cv-insertion>` callouts. |
+| `insertionsFile` | `string` | `"insertions.html"` | Filename of the insertions file within the adaptation folder. |
+
+See [Adaptation Configuration](./configuration.html) for the full JSON schema.
+
+
+## Troubleshooting
+
+* **Insertion not showing?** Check that the `insertion-id` attribute on the tag exactly matches the `id` attribute on the `<div>` in `insertions.html` (case-sensitive).
+* **Default content showing instead of adopter block?** Verify that the adaptation is active (`#/id` in the URL or `?adapt=id`), and that `insertions.html` is accessible at the expected path.
+* **No content at all?** If neither the adopter block nor the default slot content appears, ensure the `<cv-insertion>` tag has children for the fallback case, or check browser network tools to confirm the insertions file was fetched.
+* **Wrong attribution label?** Set the `name` field in the adaptation's JSON config, or override it per-tag with the `label` attribute on `<cv-insertion>`.
+
+<br>

--- a/docs/authorGuide/adaptations/samplePage.md
+++ b/docs/authorGuide/adaptations/samplePage.md
@@ -167,3 +167,34 @@ Submit via the **Sample Portal** using your student ID.
 ---
 
 *This page is personalised for **[[institutionName : all students]]**. Logged in as: [[username : Guest]]*
+
+---
+
+## Adopter Insertions
+
+The sections below demonstrate `<cv-insertion>`. Switch to the **NUS** adaptation to see the adopter-supplied notes appear in place of the default text.
+
+**View as:** [NUS](./samplePage.html?adapt=nus) · [Sample Institution](./samplePage.html?adapt=sample) · [Reset](./samplePage.html?adapt=clear)
+
+### Before Exercise 1
+
+<cv-insertion insertion-id="week1-preamble">
+
+*No institution-specific note for this section. Check the course handbook for general guidance.*
+
+</cv-insertion>
+
+### Before Exercise 2
+
+<cv-insertion insertion-id="week2-preamble">
+
+*No institution-specific note for this section.*
+
+</cv-insertion>
+
+### Before Exercise 3
+
+This insertion has **no default content** — when no matching block is found in `insertions.html`, nothing is rendered here.
+
+<cv-insertion insertion-id="week3-preamble" />
+

--- a/docs/authorGuide/integrations/setupWithMarkbind.md
+++ b/docs/authorGuide/integrations/setupWithMarkbind.md
@@ -35,7 +35,8 @@ const tagConfig = {
 	'cv-tab-header': { isCustomElement: true },
 	'cv-define-placeholder': { isCustomElement: true },
 	'cv-placeholder-input': { isCustomElement: true },
-	'cv-label': { isCustomElement: true }
+	'cv-label': { isCustomElement: true },
+    'cv-insertion': { isCustomElement: true },
 };
 
 module.exports = { getScripts, tagConfig };
@@ -52,12 +53,15 @@ function getScripts() {
 
 const tagConfig = {
   'cv-toggle': { isCustomElement: true },
+  'cv-toggle-control': { isCustomElement: true },
   'cv-tabgroup': { isCustomElement: true },
   'cv-tab': { isCustomElement: true },
   'cv-tab-body': { isCustomElement: true },
   'cv-tab-header': { isCustomElement: true },
   'cv-define-placeholder': { isCustomElement: true },
-  'cv-placeholder-input': { isCustomElement: true }
+  'cv-placeholder-input': { isCustomElement: true },
+  'cv-label': { isCustomElement: true },
+  'cv-insertion': { isCustomElement: true },
 };
 
 export { getScripts, tagConfig };

--- a/docs/versions/nus/insertions.md
+++ b/docs/versions/nus/insertions.md
@@ -1,0 +1,43 @@
+<!--
+  NUS Adaptation — Insertions File
+  =================================
+  Each <div id="..."> block defines an insertion that will be displayed
+  wherever the matching <cv-insertion insertion-id="..."> tag appears in the site.
+
+  The id must exactly match the insertion-id attribute used in the site's markup.
+  HTML content inside each div is rendered as-is inside a styled callout block.
+-->
+
+<!--  HTML VERSION:
+
+<div id="week1-preamble">
+  <p>
+    <strong>NUS CS2103T students:</strong> Before starting this section, make sure you have
+    accepted the GitHub Classroom invitation and set up your individual project repository.
+    Refer to the course schedule for this week's exact deadline.
+  </p>
+</div> 
+
+-->
+
+<div id="week1-preamble">
+
+**NUS CS2103T students:** Before starting this section, make sure you have
+accepted the GitHub Classroom invitation and set up your individual project repository.
+Refer to the course schedule for this week's exact deadline. :D
+
+</div> 
+
+<div id="week2-preamble" label="week 2">
+  <p>
+    Complete this right after Week 1's tasks. This exercise is <strong>examinable</strong> —
+    ensure you understand each step before proceeding.
+  </p>
+</div>
+
+<div id="week3-preamble">
+  <p>
+    This week's content builds directly on Week 2. If you have not finished Week 2's exercises,
+    please do so first. Raise any questions on the course forum with your team number.
+  </p>
+</div>

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2,6 +2,8 @@ import { getScriptAttributes, fetchConfig } from '$lib/utils/init-utils';
 import { initUIManager } from '$lib/app/ui-manager';
 import { AppRuntime, type RuntimeOptions } from '$lib/runtime.svelte';
 import { AdaptationManager } from '$features/adaptation/adaptation-manager';
+import { InsertionLoader } from '$features/insertion/insertion-loader';
+import { insertionStore } from '$features/insertion/insertion-store.svelte';
 import '$lib/registry';
 
 // --- No Public API Exports ---
@@ -46,6 +48,20 @@ export function initializeFromScript(): void {
       if (adaptationConfig?.id) {
         AdaptationManager.rewriteUrlIndicator(adaptationConfig.id);
       }
+
+      // Load adopter insertions (parallel concern to adaptation theme / preset).
+      // Fetch is fire-and-go before AppRuntime.start() so cv-insertion elements
+      // have data on first mount without needing a second render cycle.
+      const insertionMap = await InsertionLoader.init(
+        effectiveBaseURL,
+        adaptationConfig,
+        configFile.adaptationsPath,
+      );
+      insertionStore.init(
+        insertionMap,
+        adaptationConfig?.name ?? adaptationConfig?.id ?? null,
+        adaptationConfig !== null,
+      );
 
       const coreOptions: RuntimeOptions = {
         configFile,

--- a/src/lib/features/adaptation/types.ts
+++ b/src/lib/features/adaptation/types.ts
@@ -5,6 +5,12 @@ export interface AdaptationConfig {
     cssVariables?: Record<string, string>;
     cssFile?: string;
   };
+  /**
+   * Filename of the insertions file within the adaptation folder.
+   * Defaults to `insertions.html`.
+   * e.g. `"insertions.html"` → `{adaptationsPath}/{id}/insertions.html`
+   */
+  insertionsFile?: string;
   preset?: {
     toggles?: Record<string, 'show' | 'hide' | 'peek'>;
     tabs?: Record<string, string>;

--- a/src/lib/features/insertion/Insertion.svelte
+++ b/src/lib/features/insertion/Insertion.svelte
@@ -1,0 +1,146 @@
+<svelte:options
+  customElement={{
+    tag: 'cv-insertion',
+    props: {
+      insertionId: { reflect: false, type: 'String', attribute: 'insertion-id' },
+      label: { reflect: false, type: 'String', attribute: 'label' },
+      color: { reflect: false, type: 'String', attribute: 'color' },
+    },
+  }}
+/>
+
+<script lang="ts">
+  import { insertionStore } from '$features/insertion/insertion-store.svelte';
+
+  let {
+    insertionId = '',
+    label = '',
+    color = '',
+  }: {
+    insertionId?: string;
+    label?: string;
+    color?: string;
+  } = $props();
+
+  /**
+   * The HTML content to inject, resolved from the insertion store.
+   * `null` means "show the default slot instead".
+   */
+  let insertedHtml = $derived.by((): string | null => {
+    if (!insertionId) return null;
+    if (!insertionStore.isAdaptationActive) return null;
+    const map = insertionStore.map;
+    if (!map) return null;
+    const entry = map[insertionId];
+    return entry !== undefined ? entry.content : null;
+  });
+
+  /** Attribution label: per-tag `label` prop > per-insertion `label` from HTML > adaptation label > adaptation id */
+  let attributionLabel = $derived.by(() => {
+    if (label?.trim()) return label.trim();
+    const entry = insertionStore.map?.[insertionId];
+    if (entry?.label?.trim()) return entry.label.trim();
+    return insertionStore.adaptationLabel || null;
+  });
+
+  /** Attribution color: per-tag `color` prop > per-insertion `color` from HTML > null */
+  let attributionColor = $derived.by(() => {
+    if (color?.trim()) return color.trim();
+    const entry = insertionStore.map?.[insertionId];
+    if (entry?.color?.trim()) return entry.color.trim();
+    return null;
+  });
+
+  let hasInsertion = $derived(insertedHtml !== null);
+
+  /**
+   * Inject the raw HTML into the element using Svelte's native {@html} tag.
+   */
+</script>
+
+{#if hasInsertion}
+  <!--
+    Adopter-supplied insertion block.
+    Rendered as a visually distinct callout to make it clear this content
+    comes from the adaptation, not the original site.
+  -->
+  <aside 
+    class="cv-insertion-block" 
+    aria-label={attributionLabel || 'Adopter note'}
+    style={attributionColor ? `--cv-insertion-color: ${attributionColor};` : undefined}
+  >
+    {#if attributionLabel}
+      <div class="cv-insertion-header">
+        <span class="cv-insertion-label">{attributionLabel}</span>
+      </div>
+    {/if}
+    <!-- Raw HTML from insertions.html is injected here natively by Svelte -->
+    <div class="cv-insertion-content">
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html insertedHtml}
+    </div>
+  </aside>
+{:else}
+  <!--
+    Default slot: shown when no adaptation is active, or when no matching
+    insertion-id is found in the active adaptation's insertions.html.
+  -->
+  <slot></slot>
+{/if}
+
+<style>
+  :host {
+    display: block;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Callout wrapper                                                      */
+  /* ------------------------------------------------------------------ */
+  .cv-insertion-block {
+    display: block;
+    position: relative;
+    margin: 1rem 0;
+    padding: 0.75rem 1rem 0.75rem 1.25rem;
+    border-left: 4px solid var(--cv-insertion-color, var(--cv-primary, #814c20));
+    border-radius: 0 6px 6px 0;
+    background: color-mix(in srgb, var(--cv-insertion-color, var(--cv-primary, #814c20)) 8%, transparent);
+    font-style: normal;
+    box-sizing: border-box;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Header row (icon + label)                                           */
+  /* ------------------------------------------------------------------ */
+  .cv-insertion-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+
+  .cv-insertion-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--cv-insertion-color, var(--cv-primary, #814c20));
+    line-height: 1;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Injected content area                                               */
+  /* ------------------------------------------------------------------ */
+  .cv-insertion-content {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    /* Collapse excess vertical whitespace from injected markup */
+    overflow: hidden;
+  }
+
+  .cv-insertion-content :global(p:first-child) {
+    margin-top: 0;
+  }
+
+  .cv-insertion-content :global(p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/lib/features/insertion/insertion-loader.ts
+++ b/src/lib/features/insertion/insertion-loader.ts
@@ -1,0 +1,128 @@
+import type { AdaptationConfig } from '$features/adaptation/types';
+import type { InsertionMap } from './types';
+
+const DEFAULT_INSERTIONS_FILENAME = 'insertions.html';
+
+/**
+ * Fetches and parses the adopter-provided insertions file for the active adaptation.
+ *
+ * The file is resolved as:
+ *   `{baseUrl}/{adaptationsPath}/{id}/{insertionsFile}`
+ *
+ * where `insertionsFile` defaults to `insertions.html` but can be overridden via
+ * `adaptationConfig.insertionsFile`.
+ *
+ * The file is expected to contain zero or more `<div id="...">` elements. Each div's
+ * `id` becomes the insertion key and its `innerHTML` the insertion content.
+ *
+ * Example `insertions.html`:
+ * ```html
+ * <div id="lesson1-preamble">
+ *   <p>NUS students: complete this before your tutorial.</p>
+ * </div>
+ * ```
+ */
+export class InsertionLoader {
+  /**
+   * Loads and parses the insertions file for the given adaptation config.
+   *
+   * @param baseUrl      The site's base URL (from `data-base-url`, default `''`)
+   * @param config       The active AdaptationConfig, or `null` if no adaptation is active
+   * @param adaptationsPath  Subfolder under baseUrl where adaptation folders live (default `'versions'`)
+   * @returns            Parsed InsertionMap, or `null` if no adaptation is active or the file
+   *                     could not be fetched (404, network error, etc.)
+   */
+  static async init(
+    baseUrl = '',
+    config: AdaptationConfig | null,
+    adaptationsPath = 'versions',
+  ): Promise<InsertionMap | null> {
+    if (!config) return null;
+
+    const filename = (config.insertionsFile ?? DEFAULT_INSERTIONS_FILENAME).trim();
+    if (!filename) return null;
+
+    const url = this.buildUrl(baseUrl, adaptationsPath, config.id, filename);
+    if (!url) return null;
+
+    return this.fetchAndParse(url, config.id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private static buildUrl(
+    baseUrl: string,
+    adaptationsPath: string,
+    id: string,
+    filename: string,
+  ): string | null {
+    try {
+      const safeId = encodeURIComponent(id.trim());
+      const normalizedPath = adaptationsPath.trim().replace(/^\/+|\/+$/g, '');
+      const safePath = normalizedPath ? `${normalizedPath}/` : '';
+      const filePath = `${safePath}${safeId}/${filename}`;
+
+      // Mirror the same URL resolution used in AdaptationManager.loadAdaptationConfig
+      const directoryBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+      return new URL(filePath, new URL(directoryBase, window.location.origin)).toString();
+    } catch {
+      return null;
+    }
+  }
+
+  private static async fetchAndParse(url: string, id: string): Promise<InsertionMap | null> {
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        if (response.status !== 404) {
+          // 404 is expected when no insertions file exists — only log unexpected errors
+          console.warn(
+            `[CustardUI] Insertions file for adaptation "${id}" could not be loaded (HTTP ${response.status}).`,
+          );
+        }
+        return null;
+      }
+
+      const html = await response.text();
+      return this.parseInsertions(html);
+    } catch (err) {
+      console.warn(`[CustardUI] Failed to fetch insertions for adaptation "${id}":`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Parses an HTML string and extracts `<div id="...">` blocks into an InsertionMap.
+   * Also reads an optional `label` attribute on each div for per-insertion attribution.
+   * Uses the browser's `DOMParser` for safe, standards-compliant parsing.
+   */
+  private static parseInsertions(html: string): InsertionMap {
+    const map: InsertionMap = {};
+
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const divs = doc.querySelectorAll('div[id]');
+
+      divs.forEach((div) => {
+        const insertionId = div.id;
+        if (insertionId) {
+          const labelAttr = div.getAttribute('label');
+          const colorAttr = div.getAttribute('color');
+          map[insertionId] = {
+            content: div.innerHTML,
+            ...(labelAttr ? { label: labelAttr } : {}),
+            ...(colorAttr ? { color: colorAttr } : {}),
+          };
+        }
+      });
+    } catch (err) {
+      console.warn('[CustardUI] Failed to parse insertions HTML:', err);
+    }
+
+    return map;
+  }
+}

--- a/src/lib/features/insertion/insertion-store.svelte.ts
+++ b/src/lib/features/insertion/insertion-store.svelte.ts
@@ -1,0 +1,48 @@
+import type { InsertionMap } from './types';
+
+/**
+ * Reactive store holding the parsed insertions from the active adaptation's
+ * `insertions.html` file, plus the attribution label for the callout UI.
+ *
+ * Populated during browser initialisation by `InsertionLoader.init()` before
+ * `AppRuntime.start()` is called, so the `<cv-insertion>` custom element has
+ * data available immediately on first mount.
+ */
+class InsertionStore {
+  /**
+   * The parsed insertion map for the active adaptation.
+   * `null` means no adaptation is active (or loading has not completed).
+   * An empty object means an adaptation is active but has no insertions file
+   * (or the file is empty / failed to load).
+   */
+  map = $state<InsertionMap | null>(null);
+
+  /**
+   * The human-readable name of the active adaptation, used as the default
+   * attribution label in the callout header.
+   * Falls back to the adaptation `id` if no `name` is provided.
+   */
+  adaptationLabel = $state<string | null>(null);
+
+  /**
+   * Whether an adaptation is currently active.
+   * Distinct from `map !== null` — even a failed insertions fetch should not
+   * hide the fact that an adaptation is active.
+   */
+  isAdaptationActive = $state(false);
+
+  /**
+   * Initialises the store after the insertions file has been loaded.
+   *
+   * @param map The parsed InsertionMap, or null if loading failed / no file
+   * @param adaptationLabel The attribution label (adaptation name or id)
+   * @param isAdaptationActive Whether an adaptation is currently active
+   */
+  init(map: InsertionMap | null, adaptationLabel: string | null, isAdaptationActive: boolean): void {
+    this.map = map;
+    this.adaptationLabel = adaptationLabel;
+    this.isAdaptationActive = isAdaptationActive;
+  }
+}
+
+export const insertionStore = new InsertionStore();

--- a/src/lib/features/insertion/types.ts
+++ b/src/lib/features/insertion/types.ts
@@ -1,0 +1,31 @@
+/**
+ * A single insertion block parsed from the adopter's `insertions.html`.
+ */
+export interface InsertionEntry {
+  /** The raw HTML content of the div block. */
+  content: string;
+  /**
+   * Optional per-insertion label from the `label` attribute on the div.
+   * Overrides the adaptation-level `name` in the callout header.
+   *
+   * Example: `<div id="week1-preamble" label="Week 1 – NUS">`
+   */
+  label?: string;
+  /**
+   * Optional per-insertion color from the `color` attribute on the div.
+   * Sets the callout's border and background hue.
+   * 
+   * Example: `<div id="week1-preamble" color="#ef4444">`
+   */
+  color?: string;
+}
+
+/**
+ * A map of insertion IDs to their parsed entry.
+ * Populated by parsing the adopter-provided `insertions.html` file.
+ *
+ * Each key corresponds to the `id` attribute of a `<div>` in `insertions.html`.
+ */
+export interface InsertionMap {
+  [insertionId: string]: InsertionEntry;
+}

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -10,6 +10,8 @@ import '$features/placeholder/PlaceholderInput.svelte';
 
 import '$features/labels/components/Label.svelte';
 
+import '$features/insertion/Insertion.svelte';
+
 // Note: Svelte components register themselves upon import.
 // importing the components registers them as custom elements
 // triggers component compilation and custom element registration.

--- a/src/lib/runtime.svelte.ts
+++ b/src/lib/runtime.svelte.ts
@@ -232,7 +232,11 @@ export class AppRuntime {
     // Skip our own custom elements to avoid unnecessary scanning
     if (node.nodeType === Node.ELEMENT_NODE) {
       const el = node as HTMLElement;
-      if (el.tagName === 'CV-PLACEHOLDER' || el.tagName === 'CV-PLACEHOLDER-INPUT') {
+      if (
+        el.tagName === 'CV-PLACEHOLDER' ||
+        el.tagName === 'CV-PLACEHOLDER-INPUT' ||
+        el.tagName === 'CV-INSERTION'
+      ) {
         return;
       }
     }


### PR DESCRIPTION
**Overview of changes:**

Closes #264 by adding a new `<cv-insertion>`  element used for matching `insertions.html`/`insertions.md` that is located in the adaptation folder to allow adding html to pages.

It allows authors to declare insertion points using the new <cv-insertion> custom element:

* Adopters then create an `insertions.html` file in their adaptation configuration folder (e.g. versions/org-a/insertions.html).
* @hen the org-a adaptation is active, CustardUI fetches insertions.html, parses the DOM, and dynamically replaces the default slot content of the matching <cv-insertion> tag. The injected content is wrapped in a distinct callout block.

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [x] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:

- [ ] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
