### PR TITLE
Updates link label box in toolbar to make it look less like disabled button

### DIFF
--- a/src/lib/features/share/ShareToolbar.svelte
+++ b/src/lib/features/share/ShareToolbar.svelte
@@ -95,13 +95,16 @@
 
   <button type="button" class="btn clear" onclick={handleClear}>Clear</button>
 
-  <input
-    type="text"
-    class="label-input"
-    bind:value={shareStore.linkLabel}
-    placeholder="Label Link"
-    aria-label="Optional link label"
-  />
+  <label class="label-wrapper">
+    <span class="label-text">Label:</span>
+    <input
+      type="text"
+      class="label-input"
+      bind:value={shareStore.linkLabel}
+      placeholder="Optional link label"
+      aria-label="Optional link label"
+    />
+  </label>
 
   <button type="button" class="btn preview" onclick={handlePreview}>Preview</button>
   <button type="button" class="btn generate" onclick={handleGenerate}>Copy Link</button>
@@ -179,25 +182,44 @@
     color: #ccc;
   }
 
-  .label-input {
+  .label-wrapper {
+    display: flex;
+    align-items: center;
     background: #1a1a1a;
     border: 1px solid #4a4a4a;
-    color: #fff;
-    padding: 5px 8px;
     border-radius: 4px;
+    padding: 2px 2px 2px 8px;
     font-size: 13px;
-    width: 80px;
-    transition: width 0.2s ease, border-color 0.2s ease;
+    transition: all 0.2s ease;
+  }
+
+  .label-wrapper:focus-within {
+    border-color: #0078d4;
+    box-shadow: 0 0 0 2px rgba(0, 120, 212, 0.3);
+  }
+
+  .label-text {
+    color: #888;
+    pointer-events: none;
+  }
+
+  .label-input {
+    background: transparent;
+    border: none;
+    color: #fff;
+    padding: 4px 6px;
+    width: 70px;
+    font-size: 13px;
+    outline: none;
+    transition: width 0.2s ease;
   }
 
   .label-input::placeholder {
-    color: #666;
+    color: #555;
   }
 
   .label-input:focus {
-    width: 130px;
-    outline: none;
-    border-color: #0078d4;
+    width: 120px;
   }
 
   .btn {


### PR DESCRIPTION
**Overview of changes:**

Updates look of link label toolbar field

Previous:
<img width="969" height="69" alt="image" src="https://github.com/user-attachments/assets/e25486e7-d2c3-4f60-8d3d-a206c9764f72" />


After:
<img width="1012" height="68" alt="image" src="https://github.com/user-attachments/assets/ca6c406c-dd70-44c0-9433-47bfd948e108" />

<img width="1060" height="67" alt="image" src="https://github.com/user-attachments/assets/98dead2b-5c25-4ef1-9943-e555fccb2962" />

Related to #282

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:

- [x] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
