### PR TITLE
Add color picker for text highlight

### DIFF
--- a/src/lib/features/share/HighlightColorPicker.svelte
+++ b/src/lib/features/share/HighlightColorPicker.svelte
@@ -1,20 +1,26 @@
 <script lang="ts">
-  import { shareStore } from '$features/share/stores/share-store.svelte';
   import {
     ANNOTATION_COLORS,
-    DEFAULT_ANNOTATION_COLOR_KEY,
     type AnnotationColorKey,
   } from '$features/annotations/annotation-colors';
 
-  let { element }: { element: HTMLElement } = $props();
+  interface Props {
+    getRect: () => DOMRect;
+    colorKey: AnnotationColorKey;
+    onchange: (key: AnnotationColorKey) => void;
+    ondblclick?: (key: AnnotationColorKey) => void;
+    isVisible?: boolean;
+  }
+
+  let { getRect, colorKey, onchange, ondblclick, isVisible = true }: Props = $props();
 
   let isExpanded = $state(false);
-  let rect = $state({ top: 0, left: 0, width: 0 });
+  let rect = $state<DOMRect>(new DOMRect());
 
   $effect(() => {
-    rect = element.getBoundingClientRect();
+    rect = getRect();
     const update = () => {
-      rect = element.getBoundingClientRect();
+      rect = getRect();
     };
     window.addEventListener('scroll', update, { capture: true, passive: true });
     window.addEventListener('resize', update, { passive: true });
@@ -25,9 +31,8 @@
     };
   });
 
-  let currentColorKey = $derived(shareStore.boxColors.get(element) ?? DEFAULT_ANNOTATION_COLOR_KEY);
   let currentHex = $derived(
-    ANNOTATION_COLORS.find((c) => c.key === currentColorKey)?.hex ?? ANNOTATION_COLORS[0]!.hex,
+    ANNOTATION_COLORS.find((c) => c.key === colorKey)?.hex ?? ANNOTATION_COLORS[0]!.hex,
   );
 
   let clickTimer: ReturnType<typeof setTimeout> | null = null;
@@ -42,7 +47,7 @@
     if (clickTimer) return; // defer to potential dblclick
     clickTimer = setTimeout(() => {
       clickTimer = null;
-      shareStore.setBoxColor(element, key);
+      onchange(key);
       isExpanded = false;
     }, 220);
   }
@@ -53,7 +58,7 @@
       clearTimeout(clickTimer);
       clickTimer = null;
     }
-    shareStore.setAllBoxColors(key);
+    if (ondblclick) ondblclick(key);
     isExpanded = false;
   }
 
@@ -61,7 +66,7 @@
   let topY = $derived(rect.top);
 </script>
 
-<div class="cv-color-picker" style="left: {centerX}px; top: {topY}px;" role="none">
+<div class="cv-color-picker" class:visible={isVisible || isExpanded} style="left: {centerX}px; top: {topY}px;" role="none">
   <button
     type="button"
     class="cv-color-trigger"
@@ -78,13 +83,13 @@
         <button
           type="button"
           class="cv-color-swatch"
-          class:active={currentColorKey === color.key}
+          class:active={colorKey === color.key}
           style="background: {color.hex};"
           onclick={(e) => handleSwatchClick(e, color.key)}
           ondblclick={(e) => handleSwatchDblClick(e, color.key)}
           title="{color.label} · dbl-click to apply to all"
           aria-label={color.label}
-          aria-pressed={currentColorKey === color.key}
+          aria-pressed={colorKey === color.key}
         ></button>
       {/each}
     </div>
@@ -99,10 +104,17 @@
     flex-direction: column;
     align-items: center;
     gap: 4px;
-    pointer-events: auto;
     z-index: 9500;
     /* Nudge down so the trigger peeks above the element edge */
     margin-top: 8px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s;
+  }
+
+  .cv-color-picker.visible {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .cv-color-trigger {

--- a/src/lib/features/share/ShareOverlay.svelte
+++ b/src/lib/features/share/ShareOverlay.svelte
@@ -360,7 +360,7 @@
         colorKey={shareStore.boxColors.get(el) ?? DEFAULT_ANNOTATION_COLOR_KEY}
         onchange={(key) => shareStore.setBoxColor(el, key)}
         ondblclick={(key) => shareStore.setAllBoxColors(key)}
-        isVisible={shareStore.currentHoverTarget === el}
+        isVisible={true}
       />
       <HighlightAnnotationEditor
         getRect={() => el.getBoundingClientRect()}

--- a/src/lib/features/share/ShareOverlay.svelte
+++ b/src/lib/features/share/ShareOverlay.svelte
@@ -67,6 +67,7 @@
   let dragStart = $state<{ x: number; y: number } | null>(null);
   let dragCurrent = $state<{ x: number; y: number } | null>(null);
   let wasDragging = false;
+  let hoveredHighlightIndex = $state<number | null>(null);
 
   // Cache candidates when active to avoid repeated DOM queries
   let cachedCandidates: HTMLElement[] = [];
@@ -114,17 +115,12 @@
 
     // Check ancestors selection (level up logic)
     let parent = finalTarget.parentElement;
-    let selectedAncestor: HTMLElement | null = null;
-    while (parent) {
-      if (shareStore.selectedElements.has(parent)) {
-        selectedAncestor = parent;
-        break;
-      }
+    while (parent && !shareStore.selectedElements.has(parent)) {
       parent = parent.parentElement;
     }
 
-    if (selectedAncestor) {
-      shareStore.setHoverTarget(selectedAncestor);
+    if (parent) {
+      shareStore.setHoverTarget(parent);
       return;
     }
 
@@ -175,8 +171,35 @@
     wasDragging = false; // Ensure clean state
   }
 
+  function getHoveredHighlightIndex(clientX: number, clientY: number): number | null {
+    for (let i = 0; i < shareStore.textHighlights.length; i++) {
+      const range = textHighlightService.getRange(i);
+      if (!range) continue;
+      
+      const rects = range.getClientRects();
+      for (let j = 0; j < rects.length; j++) {
+        const r = rects[j];
+        if (
+          clientX >= r.left - 5 && clientX <= r.right + 5 &&
+          clientY >= r.top - 5 && clientY <= r.bottom + 5
+        ) {
+          return i;
+        }
+      }
+    }
+    return null;
+  }
+
   function handleMouseMove(e: MouseEvent) {
-    if (!dragStart) return;
+    if (!dragStart) {
+      if (shareStore.selectionMode === 'highlight') {
+        const target = e.target as HTMLElement;
+        if (target.closest('.cv-color-picker')) return;
+
+        hoveredHighlightIndex = getHoveredHighlightIndex(e.clientX, e.clientY);
+      }
+      return;
+    }
 
     dragCurrent = { x: e.clientX, y: e.clientY };
 
@@ -332,7 +355,13 @@
 
   {#if shareStore.selectionMode === 'box'}
     {#each [...shareStore.selectedElements] as el (el)}
-      <HighlightColorPicker element={el} />
+      <HighlightColorPicker 
+        getRect={() => el.getBoundingClientRect()}
+        colorKey={shareStore.boxColors.get(el) ?? DEFAULT_ANNOTATION_COLOR_KEY}
+        onchange={(key) => shareStore.setBoxColor(el, key)}
+        ondblclick={(key) => shareStore.setAllBoxColors(key)}
+        isVisible={shareStore.currentHoverTarget === el}
+      />
       <HighlightAnnotationEditor
         getRect={() => el.getBoundingClientRect()}
         annotation={shareStore.boxAnnotations.get(el)?.text ?? ''}
@@ -346,6 +375,13 @@
     {#each shareStore.textHighlights as desc, i (i)}
       {@const resolvedRange = textHighlightService.getRange(i)}
       {#if resolvedRange}
+        <HighlightColorPicker 
+          getRect={() => textHighlightService.getAnchorRect(i) ?? new DOMRect()}
+          colorKey={desc.color ?? DEFAULT_ANNOTATION_COLOR_KEY}
+          onchange={(key) => shareStore.setTextHighlightColor(i, key)}
+          ondblclick={(key) => shareStore.setAllTextHighlightColors(key)}
+          isVisible={hoveredHighlightIndex === i}
+        />
         <HighlightAnnotationEditor
           getRect={() => textHighlightService.getAnchorRect(i) ?? new DOMRect()}
           annotation={desc.annotation ?? ''}

--- a/src/lib/features/share/stores/share-store.svelte.ts
+++ b/src/lib/features/share/stores/share-store.svelte.ts
@@ -211,6 +211,19 @@ export class ShareStore {
     textHighlightService.applyDescriptors(this.textHighlights, true);
   }
 
+  setTextHighlightColor(index: number, color: AnnotationColorKey) {
+    const desc = this.textHighlights[index];
+    if (!desc) return;
+    const updated = { ...desc, color };
+    this.textHighlights = this.textHighlights.map((d, i) => (i === index ? updated : d));
+    textHighlightService.applyDescriptors(this.textHighlights, true);
+  }
+
+  setAllTextHighlightColors(color: AnnotationColorKey) {
+    this.textHighlights = this.textHighlights.map((desc) => ({ ...desc, color }));
+    textHighlightService.applyDescriptors(this.textHighlights, true);
+  }
+
   setBoxColor(el: HTMLElement, color: AnnotationColorKey) {
     this.boxColors.set(el, color);
   }


### PR DESCRIPTION
**Overview of changes:**

Add color picker that appears on cursor location of text highlight to easily change color of text highlights, similar to box highlights.

Fixes #279

<img width="851" height="259" alt="image" src="https://github.com/user-attachments/assets/28be19db-ff14-493a-a9b1-c148e8caa4c4" />

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [x] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:

- [x] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
