### PR TITLE
Update insertions styling 

### DIFF
--- a/docs/authorGuide/adaptations/insertions.md
+++ b/docs/authorGuide/adaptations/insertions.md
@@ -25,7 +25,7 @@
 
 </cv-insertion>
 
-<cv-insertion insertion-id="week2-preamble">
+<cv-insertion insertion-id="week2-preamble" align="justify" outline="none">
 
 *No institution-specific note for this section.*
 
@@ -62,7 +62,7 @@ Each adopter creates an `insertions.html` file in their adaptation folder. Each 
 </div> 
 
 <!-- versions/org-a/insertions.md (for MarkBind or SSGs):-->
-<div id="week2-preamble" label="week 2" color="#ef4444">
+<div id="week2-preamble" color="#ef4444">
 
 Complete this right after Week 1's tasks. This exercise is **examinable** —
 ensure you understand each step before proceeding.
@@ -86,11 +86,13 @@ You can include any HTML inside the `<div>` blocks: paragraphs, lists, bold text
 
 ### Attributes of `<cv-insertion>`
 
-| Name           | Type     | Default      | Description |
-| -------------- | -------- | ------------ | ----------- |
-| `insertion-id` | `string` | **required** | The lookup key. Must match the `id` attribute of a `<div>` in the active adaptation's `insertions.html`. |
-| `label`        | `string` | —            | Attribution label shown in the callout header. Takes highest precedence, overriding both the `<div>` attribute and the adaptation `name` config. |
-| `color`        | `string` | —            | Custom color for the insertion callout (e.g. `#ef4444`). Takes highest precedence, overriding both the `<div>` attribute and the adaptation `--cv-primary` theme. |
+| Name           | Type      | Default      | Description |
+| -------------- | --------- | ------------ | ----------- |
+| `insertion-id` | `string`  | **required** | The lookup key. Must match the `id` attribute of a `<div>` in the active adaptation's `insertions.html`. |
+| `color`        | `string`  | —            | Custom color for the inserted callout (e.g. `#ef4444`). Takes highest precedence, overriding the `<div>` attribute. |
+| `align`        | `string`  | —            | Text alignment for both the injected content and the fallback slot (`left`, `center`, `right`, or `justify`). |
+| `hide-badge`   | `boolean` | `false`      | When present, the attribution badge ("inserted for version...") is completely hidden. |
+| `outline`      | `string`  | `"dashed"`   | Border style for the callout box (`dashed`, `solid`, or `none`). |
 
 **Slot (default content):** Any children inside `<cv-insertion>` are rendered when no adaptation is active, or when the active adaptation has no matching `id` in its `insertions.html`.
 
@@ -101,13 +103,10 @@ You can include any HTML inside the `<div>` blocks: paragraphs, lists, bold text
 | Name    | Type     | Default      | Description |
 | ------- | -------- | ------------ | ----------- |
 | `id`    | `string` | **required** | The lookup key. Must match the `insertion-id` of a `<cv-insertion>` tag. |
-| `label` | `string` | —            | Attribution label shown in the callout header. Overrides the adaptation's `name` config, but is overridden by the `<cv-insertion>` tag's `label` attribute. |
-| `color` | `string` | —            | Custom color for the callout (e.g. `#ef4444`). Overrides the adaptation's `--cv-primary` theme, but is overridden by the `<cv-insertion>` tag's `color` attribute. |
+| `color` | `string` | —            | Custom color for the callout (e.g. `#ef4444`). Overridden by the `<cv-insertion>` tag's `color` attribute. |
+| `align` | `string` | —            | Text alignment for the injected content (`left`, `center`, `right`, or `justify`). Overridden by the `<cv-insertion>` tag's `align` attribute. |
+| `outline` | `string` | —            | Border style for the callout box (`dashed`, `solid`, or `none`). Overridden by the `<cv-insertion>` tag's `outline` attribute. |
 
-
-### With Attribution Label
-
-Use the `label` attribute to override the attribution label shown in the callout header for a specific insertion point. When omitted, the label defaults to the adaptation's `name` field from its JSON config.
 
 ### With Custom Color
 
@@ -119,7 +118,7 @@ Use the `color` attribute to override the color of the callout box and its label
 </cv-insertion>
 ```
 
-When omitted, the color defaults to the active adaptation's `--cv-primary` theme color.
+When omitted, the color defaults to a neutral gray.
 
 ### No Default Content
 
@@ -191,7 +190,7 @@ The `insertionsFile` field is optional and belongs at the top level of the adapt
 }
 ```
 
-The `name` field is used as the default attribution label in all `<cv-insertion>` callout headers for this adaptation (unless overridden per-tag via `name` attribute).
+The `name` field is used as the attribution label in all `<cv-insertion>` callout badges for this adaptation.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -206,6 +205,6 @@ See [Adaptation Configuration](./configuration.html) for the full JSON schema.
 * **Insertion not showing?** Check that the `insertion-id` attribute on the tag exactly matches the `id` attribute on the `<div>` in `insertions.html` (case-sensitive).
 * **Default content showing instead of adopter block?** Verify that the adaptation is active (`#/id` in the URL or `?adapt=id`), and that `insertions.html` is accessible at the expected path.
 * **No content at all?** If neither the adopter block nor the default slot content appears, ensure the `<cv-insertion>` tag has children for the fallback case, or check browser network tools to confirm the insertions file was fetched.
-* **Wrong attribution label?** Set the `name` field in the adaptation's JSON config, or override it per-tag with the `label` attribute on `<cv-insertion>`.
+* **Wrong attribution label?** Set the `name` field in the adaptation's JSON config.
 
 <br>

--- a/docs/authorGuide/adaptations/insertions.md
+++ b/docs/authorGuide/adaptations/insertions.md
@@ -14,7 +14,7 @@
 
 **Insertions** let adopters inject their own content at specific points in site pages — without modifying the original source. They are ideal for institution-specific preambles, deadline reminders, or notes before exercises that the original site author has designated as injectable.
 
-**View as:** [NUS](./insertions.html?adapt=nus) · [Reset](./insertions.html?adapt=clear)
+**View Adaptations:** [NUS](./insertions.html?adapt=nus) · [Reset to Default](./insertions.html?adapt=clear)
 
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">html</variable>
@@ -25,7 +25,7 @@
 
 </cv-insertion>
 
-<cv-insertion insertion-id="week2-preamble" align="justify" outline="none">
+<cv-insertion insertion-id="week2-preamble" align="justify" outline="none" default-style="none">
 
 *No institution-specific note for this section.*
 
@@ -33,7 +33,7 @@
 </variable>
 </include>
 
-When the active adaptation has a matching block in its `insertions.html`, the `<cv-insertion>` element renders it as a styled adopter callout. When there is no matching block — or no adaptation is active — the **default slot content** (children) is shown instead.
+When the active adaptation has a matching block in its `insertions.html`, the `<cv-insertion>` element renders it as a styled adopter callout. When there is no matching block — or no adaptation is active — the **default slot content** (children) is shown instead. By default, this fallback content is also rendered inside the same styled callout box to prevent layout shifts. The styling can be disabled.
 
 ### Basic Syntax
 
@@ -43,9 +43,9 @@ When the active adaptation has a matching block in its `insertions.html`, the `<
 </cv-insertion>
 ```
 
-> `insertion-id` attribute is used for the lookup key for the `<cv-insertion insertion-id="...">` element, while the matching `<div id="...">` block in `insertions.html` uses `id` as the lookup key. This is because standard `id` attributes must be unique per page. This allows you to safely reuse the same insertion point multiple times without breaking HTML validation or browser anchor routing.
+> `insertion-id` attribute is used as the lookup key for the matching `id` of the `<div id="...">` block in `insertions.html`. As `id` should be unique per page, this allows safe reuse of insertion points multiple times across a page.
 
-### `insertions.html` Format
+### Source `insertions.html` Format
 
 Each adopter creates an `insertions.html` file in their adaptation folder. Each `<div id="...">` element defines one injection block — the `id` is the lookup key and the `innerHTML` is what gets rendered.
 
@@ -55,7 +55,7 @@ Each adopter creates an `insertions.html` file in their adaptation folder. Each 
 <!-- versions/org-a/insertions.html -->
 <div id="week1-preamble">
   <p>
-    <strong>NUS CS2103T students:</strong> Before starting this section, make sure you have
+    <strong>Students:</strong> Before starting this section, make sure you have
     accepted the GitHub Classroom invitation and set up your individual project repository.
     Refer to the course schedule for this week's exact deadline.
   </p>
@@ -70,31 +70,38 @@ ensure you understand each step before proceeding.
 </div>
 ```
 
+<cv-insertion default-badge="org-a">
+  <p>
+    <strong>Students:</strong> Before starting this section, make sure you have
+    accepted the GitHub Classroom invitation and set up your individual project repository.
+    Refer to the course schedule for this week's exact deadline.
+  </p>
+</cv-insertion>
+
+<cv-insertion color="#ef4444" default-badge="org-a">
+
+Complete this right after Week 1's tasks. This exercise is **examinable** —
+ensure you understand each step before proceeding.
+
+</cv-insertion>
+
 The `insertion-id` links the tag to a `<div id="...">` in the adopter's `insertions.html`. When a match is found, the adopter's HTML replaces the default slot content and is wrapped in a labelled callout block.
 
-<box type="info">
+* Only `<div id="...">` elements are parsed in `insertion.html`. Other elements (paragraphs, comments, etc.) not contained in these `div` elements are ignored.
+* You can include any HTML inside the `<div>` blocks: paragraphs, lists, bold text, links, etc.
 
-Only `<div id="...">` elements are extracted — at any depth in the file. Other top-level elements (paragraphs, comments, etc.) are ignored.
-
-</box>
-
-<box type="tip">
-
-You can include any HTML inside the `<div>` blocks: paragraphs, lists, bold text, links, etc. The content is rendered as-is inside the adopter callout.
-
-</box>
 
 ### Attributes of `<cv-insertion>`
 
 | Name           | Type      | Default      | Description |
 | -------------- | --------- | ------------ | ----------- |
-| `insertion-id` | `string`  | **required** | The lookup key. Must match the `id` attribute of a `<div>` in the active adaptation's `insertions.html`. |
+| `insertion-id` | `string`  | —            | The lookup key. Must match the `id` attribute of a `<div>` in the active adaptation's `insertions.html`. If omitted, the element acts as a static UI component that is never replaced. |
 | `color`        | `string`  | —            | Custom color for the inserted callout (e.g. `#ef4444`). Takes highest precedence, overriding the `<div>` attribute. |
 | `align`        | `string`  | —            | Text alignment for both the injected content and the fallback slot (`left`, `center`, `right`, or `justify`). |
 | `hide-badge`   | `boolean` | `false`      | When present, the attribution badge ("inserted for version...") is completely hidden. |
 | `outline`      | `string`  | `"dashed"`   | Border style for the callout box (`dashed`, `solid`, or `none`). |
-
-**Slot (default content):** Any children inside `<cv-insertion>` are rendered when no adaptation is active, or when the active adaptation has no matching `id` in its `insertions.html`.
+| `default-style`| `string`  | `"callout"`  | How the default slot content is styled when no adaptation matches (`callout` or `none`). |
+| `default-badge`| `string`  | —            | Badge text to show when rendering the default slot as a callout (e.g. `Base Version`). |
 
 <br>
 
@@ -108,26 +115,31 @@ You can include any HTML inside the `<div>` blocks: paragraphs, lists, bold text
 | `outline` | `string` | —            | Border style for the callout box (`dashed`, `solid`, or `none`). Overridden by the `<cv-insertion>` tag's `outline` attribute. |
 
 
-### With Custom Color
+### Component Rendering Behavior
 
-Use the `color` attribute to override the color of the callout box and its label. This is useful for color-coding specific insertions (e.g. red for deadlines, green for tips). You can provide any valid CSS color, including hex codes like `#ef4444`.
+The `<cv-insertion>` component behaves differently depending on the context:
 
-```html
-<cv-insertion insertion-id="exercise-1-preamble" color="#ef4444">
-  Default content shown when no insertion matches.
-</cv-insertion>
-```
+1. **Default / No Active Adaptation**: When viewing the base site, the default content is rendered.
+1. **Active Adaptation** with _Matching `<div id>` in `insertions.html`_: `Div` content is rendered inside the callout box.
+1. **Active Adaptation** with _No Matching `insertion-id` to `<div id>`_: If an adaptation is active, but its `insertions.html` does not contain a `div` element with `id` corresponding to the `insertion-id`, nothing is rendered.
 
-When omitted, the color defaults to a neutral gray.
+Alternatively, to use `<cv-insertion>` as a **pure UI element** that is never replaced, omit the `insertion-id` attribute. In this case, the component acts as a static UI wrapper that is never replaced, and will always render its default content across all adaptations.
 
-### No Default Content
 
-If an insertion point has no meaningful default, you can use a self-closing tag. The element renders nothing when no matching block is found:
+### Default Content in Insertions
+
+When the default content is displayed, it is rendered inside a styled callout box by default (`default-style="callout"`) so that the visual layout remains consistent with the adaptations. You can disable this by setting `default-style="none"` to render the fallback content completely unstyled/inline.
+
+
+**Setting no default content**: If an insertion point has no meaningful default, you can use a self-closing tag. The element automatically renders nothing when there is no active adaptation enabled.
 
 ```html
 <cv-insertion insertion-id="week3-note" />
 ```
 
+<cv-insertion insertion-id="week3-note"/>
+
+**View in Adaptation:** [NUS](./insertions.html?adapt=nus#default-content-in-insertions) · [Reset to Default](./insertions.html?adapt=clear#default-content-in-insertions)
 
 ## File Placement
 

--- a/docs/authorGuide/adaptations/insertions.md
+++ b/docs/authorGuide/adaptations/insertions.md
@@ -20,16 +20,15 @@
 <variable name="highlightStyle">html</variable>
 <variable name="code">
 <cv-insertion insertion-id="week1-preamble">
-
-*No institution-specific note for this section.*
-
+ <md>*No note for this section.*</md>
 </cv-insertion>
 
-<cv-insertion insertion-id="week2-preamble" align="justify" outline="none" default-style="none">
+<cv-insertion insertion-id="week2-preamble" align="justify" default-style="none">
 
-*No institution-specific note for this section.*
-
+*No note for this section.*
 </cv-insertion>
+
+<cv-insertion insertion-id="week3-note" outline="solid"/>
 </variable>
 </include>
 
@@ -99,9 +98,9 @@ The `insertion-id` links the tag to a `<div id="...">` in the adopter's `inserti
 | `color`        | `string`  | —            | Custom color for the inserted callout (e.g. `#ef4444`). Takes highest precedence, overriding the `<div>` attribute. |
 | `align`        | `string`  | —            | Text alignment for both the injected content and the fallback slot (`left`, `center`, `right`, or `justify`). |
 | `hide-badge`   | `boolean` | `false`      | When present, the attribution badge ("inserted for version...") is completely hidden. |
-| `outline`      | `string`  | `"dashed"`   | Border style for the callout box (`dashed`, `solid`, or `none`). |
-| `default-style`| `string`  | `"callout"`  | How the default slot content is styled when no adaptation matches (`callout` or `none`). |
-| `default-badge`| `string`  | —            | Badge text to show when rendering the default slot as a callout (e.g. `Base Version`). |
+| `outline`      | `string`  | `"dashed"`   | Border style for the callout box (`dashed`, `solid`, or `none`). Applies to both default content and adaptation content. |
+| `default-style`| `string`  | `"callout"`  | How the default slot content is styled when no adaptation matches (`callout` or `none`). Does not apply when adaptations are active. |
+| `default-badge`| `string`  | —            | Badge text to show when rendering the default slot as a callout (e.g. `Base Version`). Does not apply when adaptations are active. |
 
 <br>
 

--- a/docs/versions/nus/insertions.md
+++ b/docs/versions/nus/insertions.md
@@ -12,7 +12,7 @@
 
 <div id="week1-preamble">
   <p>
-    <strong>NUS CS2103T students:</strong> Before starting this section, make sure you have
+    <strong>Students:</strong> Before starting this section, make sure you have
     accepted the GitHub Classroom invitation and set up your individual project repository.
     Refer to the course schedule for this week's exact deadline.
   </p>
@@ -22,7 +22,7 @@
 
 <div id="week1-preamble">
 
-**NUS CS2103T students:** Before starting this section, make sure you have
+**Students:** Before starting this section, make sure you have
 accepted the GitHub Classroom invitation and set up your individual project repository.
 Refer to the course schedule for this week's exact deadline. :D
 
@@ -40,4 +40,9 @@ Refer to the course schedule for this week's exact deadline. :D
     This week's content builds directly on Week 2. If you have not finished Week 2's exercises,
     please do so first. Raise any questions on the course forum with your team number.
   </p>
+</div>
+
+<div id="week3-note">
+
+Note: It is **week 3**.
 </div>

--- a/docs/versions/nus/insertions.md
+++ b/docs/versions/nus/insertions.md
@@ -28,7 +28,7 @@ Refer to the course schedule for this week's exact deadline. :D
 
 </div> 
 
-<div id="week2-preamble" label="week 2">
+<div id="week2-preamble">
   <p>
     Complete this right after Week 1's tasks. This exercise is <strong>examinable</strong> —
     ensure you understand each step before proceeding.

--- a/src/lib/features/insertion/Insertion.svelte
+++ b/src/lib/features/insertion/Insertion.svelte
@@ -3,8 +3,10 @@
     tag: 'cv-insertion',
     props: {
       insertionId: { reflect: false, type: 'String', attribute: 'insertion-id' },
-      label: { reflect: false, type: 'String', attribute: 'label' },
       color: { reflect: false, type: 'String', attribute: 'color' },
+      align: { reflect: false, type: 'String', attribute: 'align' },
+      hideBadge: { reflect: false, type: 'Boolean', attribute: 'hide-badge' },
+      outline: { reflect: false, type: 'String', attribute: 'outline' },
     },
   }}
 />
@@ -14,12 +16,16 @@
 
   let {
     insertionId = '',
-    label = '',
     color = '',
+    align = '',
+    hideBadge = false,
+    outline,
   }: {
     insertionId?: string;
-    label?: string;
     color?: string;
+    align?: string;
+    hideBadge?: boolean;
+    outline?: string;
   } = $props();
 
   /**
@@ -35,11 +41,8 @@
     return entry !== undefined ? entry.content : null;
   });
 
-  /** Attribution label: per-tag `label` prop > per-insertion `label` from HTML > adaptation label > adaptation id */
+  /** Attribution label: adaptation label > adaptation id */
   let attributionLabel = $derived.by(() => {
-    if (label?.trim()) return label.trim();
-    const entry = insertionStore.map?.[insertionId];
-    if (entry?.label?.trim()) return entry.label.trim();
     return insertionStore.adaptationLabel || null;
   });
 
@@ -49,6 +52,22 @@
     const entry = insertionStore.map?.[insertionId];
     if (entry?.color?.trim()) return entry.color.trim();
     return null;
+  });
+
+  /** Alignment: per-tag `align` prop > per-insertion `align` from HTML > null */
+  let computedAlign = $derived.by(() => {
+    if (align?.trim()) return align.trim();
+    const entry = insertionStore.map?.[insertionId];
+    if (entry?.align?.trim()) return entry.align.trim();
+    return null;
+  });
+
+  /** Outline: per-tag `outline` prop > per-insertion `outline` from HTML > 'dashed' */
+  let computedOutline = $derived.by(() => {
+    if (outline?.trim()) return outline.trim();
+    const entry = insertionStore.map?.[insertionId];
+    if (entry?.outline?.trim()) return entry.outline.trim();
+    return 'dashed';
   });
 
   let hasInsertion = $derived(insertedHtml !== null);
@@ -68,24 +87,33 @@
     class="cv-insertion-block" 
     aria-label={attributionLabel || 'Adopter note'}
     style={attributionColor ? `--cv-insertion-color: ${attributionColor};` : undefined}
+    style:text-align={computedAlign || undefined}
+    style:border-style={computedOutline}
+    style:border-width={computedOutline === 'none' ? '0' : undefined}
   >
-    {#if attributionLabel}
-      <div class="cv-insertion-header">
-        <span class="cv-insertion-label">{attributionLabel}</span>
-      </div>
-    {/if}
     <!-- Raw HTML from insertions.html is injected here natively by Svelte -->
     <div class="cv-insertion-content">
       <!-- eslint-disable-next-line svelte/no-at-html-tags -->
       {@html insertedHtml}
     </div>
+    {#if attributionLabel && !hideBadge}
+      <div class="cv-insertion-badge">
+        inserted for version: <strong>{attributionLabel}</strong>
+      </div>
+    {/if}
   </aside>
 {:else}
   <!--
     Default slot: shown when no adaptation is active, or when no matching
     insertion-id is found in the active adaptation's insertions.html.
   -->
-  <slot></slot>
+  {#if computedAlign}
+    <div style:text-align={computedAlign}>
+      <slot></slot>
+    </div>
+  {:else}
+    <slot></slot>
+  {/if}
 {/if}
 
 <style>
@@ -99,31 +127,13 @@
   .cv-insertion-block {
     display: block;
     position: relative;
-    margin: 1rem 0;
-    padding: 0.75rem 1rem 0.75rem 1.25rem;
-    border-left: 4px solid var(--cv-insertion-color, var(--cv-primary, #814c20));
-    border-radius: 0 6px 6px 0;
-    background: color-mix(in srgb, var(--cv-insertion-color, var(--cv-primary, #814c20)) 8%, transparent);
+    margin: 1.5rem 0;
+    padding: 1.25rem 1.5rem;
+    border: 1px dashed var(--cv-insertion-color, #a1a1aa);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--cv-insertion-color, transparent) 5%, #f4f4f5);
     font-style: normal;
     box-sizing: border-box;
-  }
-
-  /* ------------------------------------------------------------------ */
-  /* Header row (icon + label)                                           */
-  /* ------------------------------------------------------------------ */
-  .cv-insertion-header {
-    display: flex;
-    align-items: center;
-    margin-bottom: 0.5rem;
-  }
-
-  .cv-insertion-label {
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--cv-insertion-color, var(--cv-primary, #814c20));
-    line-height: 1;
   }
 
   /* ------------------------------------------------------------------ */
@@ -132,8 +142,8 @@
   .cv-insertion-content {
     font-size: 0.95rem;
     line-height: 1.6;
-    /* Collapse excess vertical whitespace from injected markup */
-    overflow: hidden;
+    /* Allow text-align styles from user HTML to take effect properly */
+    width: 100%;
   }
 
   .cv-insertion-content :global(p:first-child) {
@@ -142,5 +152,29 @@
 
   .cv-insertion-content :global(p:last-child) {
     margin-bottom: 0;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Badge                                                              */
+  /* ------------------------------------------------------------------ */
+  .cv-insertion-badge {
+    position: absolute;
+    bottom: 0;
+    right: 1.5rem;
+    transform: translateY(50%);
+    background: #ffffff;
+    border: 1px solid var(--cv-insertion-color, #a1a1aa);
+    padding: 0.15rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    color: var(--cv-insertion-color, #a1a1aa);
+    line-height: 1.4;
+    white-space: nowrap;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  }
+
+  .cv-insertion-badge strong {
+    color: var(--cv-insertion-color, #71717a);
+    font-weight: 600;
   }
 </style>

--- a/src/lib/features/insertion/Insertion.svelte
+++ b/src/lib/features/insertion/Insertion.svelte
@@ -7,6 +7,8 @@
       align: { reflect: false, type: 'String', attribute: 'align' },
       hideBadge: { reflect: false, type: 'Boolean', attribute: 'hide-badge' },
       outline: { reflect: false, type: 'String', attribute: 'outline' },
+      defaultStyle: { reflect: false, type: 'String', attribute: 'default-style' },
+      defaultBadge: { reflect: false, type: 'String', attribute: 'default-badge' },
     },
   }}
 />
@@ -20,12 +22,16 @@
     align = '',
     hideBadge = false,
     outline,
+    defaultStyle = 'callout',
+    defaultBadge = '',
   }: {
     insertionId?: string;
     color?: string;
     align?: string;
     hideBadge?: boolean;
     outline?: string;
+    defaultStyle?: string;
+    defaultBadge?: string;
   } = $props();
 
   /**
@@ -72,48 +78,77 @@
 
   let hasInsertion = $derived(insertedHtml !== null);
 
+  let hasDefaultContent = $state(false);
+  
+  let showAsCallout = $derived(hasInsertion || (defaultStyle !== 'none' && hasDefaultContent));
+
+  function updateHasDefaultContent(slot: HTMLSlotElement) {
+    if (!slot) return;
+    const nodes = slot.assignedNodes();
+    hasDefaultContent = nodes.some(n => 
+      (n.nodeType === 1) || 
+      (n.nodeType === 3 && n.textContent?.trim() !== '')
+    );
+  }
+
+  const initSlotWrapper = (node: HTMLElement) => {
+    const slot = node.querySelector('slot');
+    if (!slot) return;
+    
+    slot.addEventListener('slotchange', () => {
+      updateHasDefaultContent(slot);
+    });
+
+    queueMicrotask(() => {
+      updateHasDefaultContent(slot);
+    });
+  };
+
+  /**
+   * If an adaptation is active but this specific insertion-id is not provided, 
+   * the element should completely disappear (unless it's a pure UI element with no id).
+   */
+  let shouldRender = $derived(
+    !insertionStore.isAdaptationActive || 
+    hasInsertion || 
+    !insertionId
+  );
+
   /**
    * Inject the raw HTML into the element using Svelte's native {@html} tag.
    */
 </script>
 
-{#if hasInsertion}
-  <!--
-    Adopter-supplied insertion block.
-    Rendered as a visually distinct callout to make it clear this content
-    comes from the adaptation, not the original site.
-  -->
-  <aside 
-    class="cv-insertion-block" 
-    aria-label={attributionLabel || 'Adopter note'}
-    style={attributionColor ? `--cv-insertion-color: ${attributionColor};` : undefined}
+{#if shouldRender}
+  <div 
+    class:cv-insertion-block={showAsCallout} 
+    class:cv-insertion-unstyled={!showAsCallout}
+    aria-label={showAsCallout ? (hasInsertion ? (attributionLabel || 'Adopter note') : (defaultBadge || 'Note')) : undefined}
+    style={showAsCallout && attributionColor ? `--cv-insertion-color: ${attributionColor};` : undefined}
     style:text-align={computedAlign || undefined}
-    style:border-style={computedOutline}
-    style:border-width={computedOutline === 'none' ? '0' : undefined}
+    style:border-style={showAsCallout ? computedOutline : undefined}
+    style:border-width={showAsCallout && computedOutline === 'none' ? '0' : undefined}
   >
-    <!-- Raw HTML from insertions.html is injected here natively by Svelte -->
-    <div class="cv-insertion-content">
-      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-      {@html insertedHtml}
+    <div class:cv-insertion-content={showAsCallout}>
+      {#if hasInsertion}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html insertedHtml}
+      {:else}
+        <div style="display: contents" use:initSlotWrapper>
+          <slot></slot>
+        </div>
+      {/if}
     </div>
-    {#if attributionLabel && !hideBadge}
+    {#if showAsCallout && hasInsertion && attributionLabel && !hideBadge}
       <div class="cv-insertion-badge">
         inserted for version: <strong>{attributionLabel}</strong>
       </div>
+    {:else if showAsCallout && !hasInsertion && defaultBadge && !hideBadge}
+      <div class="cv-insertion-badge">
+        <strong>{defaultBadge}</strong>
+      </div>
     {/if}
-  </aside>
-{:else}
-  <!--
-    Default slot: shown when no adaptation is active, or when no matching
-    insertion-id is found in the active adaptation's insertions.html.
-  -->
-  {#if computedAlign}
-    <div style:text-align={computedAlign}>
-      <slot></slot>
-    </div>
-  {:else}
-    <slot></slot>
-  {/if}
+  </div>
 {/if}
 
 <style>

--- a/src/lib/features/insertion/Insertion.svelte
+++ b/src/lib/features/insertion/Insertion.svelte
@@ -166,7 +166,6 @@
     padding: 1.25rem 1.5rem;
     border: 1px dashed var(--cv-insertion-color, #a1a1aa);
     border-radius: 8px;
-    background: color-mix(in srgb, var(--cv-insertion-color, transparent) 5%, #f4f4f5);
     font-style: normal;
     box-sizing: border-box;
   }
@@ -197,7 +196,7 @@
     bottom: 0;
     right: 1.5rem;
     transform: translateY(50%);
-    background: #ffffff;
+    background: var(--cv-insertion-bg, var(--bs-body-bg, #ffffff));
     border: 1px solid var(--cv-insertion-color, #a1a1aa);
     padding: 0.15rem 0.75rem;
     border-radius: 9999px;

--- a/src/lib/features/insertion/insertion-loader.ts
+++ b/src/lib/features/insertion/insertion-loader.ts
@@ -96,7 +96,6 @@ export class InsertionLoader {
 
   /**
    * Parses an HTML string and extracts `<div id="...">` blocks into an InsertionMap.
-   * Also reads an optional `label` attribute on each div for per-insertion attribution.
    * Uses the browser's `DOMParser` for safe, standards-compliant parsing.
    */
   private static parseInsertions(html: string): InsertionMap {
@@ -110,12 +109,14 @@ export class InsertionLoader {
       divs.forEach((div) => {
         const insertionId = div.id;
         if (insertionId) {
-          const labelAttr = div.getAttribute('label');
           const colorAttr = div.getAttribute('color');
+          const alignAttr = div.getAttribute('align');
+          const outlineAttr = div.getAttribute('outline');
           map[insertionId] = {
             content: div.innerHTML,
-            ...(labelAttr ? { label: labelAttr } : {}),
             ...(colorAttr ? { color: colorAttr } : {}),
+            ...(alignAttr ? { align: alignAttr } : {}),
+            ...(outlineAttr ? { outline: outlineAttr } : {}),
           };
         }
       });

--- a/src/lib/features/insertion/types.ts
+++ b/src/lib/features/insertion/types.ts
@@ -5,19 +5,24 @@ export interface InsertionEntry {
   /** The raw HTML content of the div block. */
   content: string;
   /**
-   * Optional per-insertion label from the `label` attribute on the div.
-   * Overrides the adaptation-level `name` in the callout header.
-   *
-   * Example: `<div id="week1-preamble" label="Week 1 – NUS">`
-   */
-  label?: string;
-  /**
    * Optional per-insertion color from the `color` attribute on the div.
    * Sets the callout's border and background hue.
    * 
    * Example: `<div id="week1-preamble" color="#ef4444">`
    */
   color?: string;
+  /**
+   * Optional per-insertion alignment from the `align` attribute on the div.
+   * 
+   * Example: `<div id="week1-preamble" align="center">`
+   */
+  align?: string;
+  /**
+   * Optional per-insertion outline from the `outline` attribute on the div.
+   * 
+   * Example: `<div id="week1-preamble" outline="solid">`
+   */
+  outline?: string;
 }
 
 /**


### PR DESCRIPTION
**Overview of changes:**

* Updated styling of the `<cv-insertion>` component
* Add attribute options for text alignment, outline styles, etc.
* Updated documentation
* Update some behavior as well (e.g. default content is now styled, with an option to remove border).

<img width="1187" height="790" alt="image" src="https://github.com/user-attachments/assets/9bfebb1c-a18e-4972-8c70-f79d60c51f76" />

Related to #278

<!-- Add link to issue, or summary of changes.-->

**[SEMVER](https://semver.org/) impact of the PR**:

- [ ] Major (when you make incompatible API changes)
- [x] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

**Merge Instructions**:

- [ ] For feature branches merging to **develop**: Prefer **Squash and Merge**.
- [ ] For release/hotfix branches merging to **main**, or subsequent sync back-merges merging to **develop**: ONLY use **Create a Merge Commit**.
